### PR TITLE
feat: implement plain tooltip component

### DIFF
--- a/frontend/src/components/Tooltips/TooltipExample.module.scss
+++ b/frontend/src/components/Tooltips/TooltipExample.module.scss
@@ -1,0 +1,10 @@
+.container {
+  display: flex;
+
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: min-content;
+  width: 100%;
+  height: min-content;
+}

--- a/frontend/src/components/Tooltips/TooltipExample.tsx
+++ b/frontend/src/components/Tooltips/TooltipExample.tsx
@@ -1,0 +1,28 @@
+import TooltipProvider from './TooltipProvider';
+
+import styles from './TooltipExample.module.scss';
+import { IconButton, Icon, FilledIconButton } from '../material-components/IconButton/IconButton';
+
+const exampleText = '안녕하세요';
+
+const TooltipsExample = () => {
+  return (
+    <div className={styles['container']}>
+      <p>요소 간 시각적인 구분이 있는 경우 기본 간격 (4px)</p>
+      <TooltipProvider text={exampleText}>
+        <FilledIconButton>
+          <Icon>check</Icon>
+        </FilledIconButton>
+      </TooltipProvider>
+
+      <p>요소 간 시각적인 구분이 없는 경우 Provider에 extraGap=true를 전달 (8px)</p>
+      <TooltipProvider text={exampleText} extraGap={true}>
+        <IconButton>
+          <Icon>check</Icon>
+        </IconButton>
+      </TooltipProvider>
+    </div>
+  );
+};
+
+export default TooltipsExample;

--- a/frontend/src/components/Tooltips/TooltipProvider.module.scss
+++ b/frontend/src/components/Tooltips/TooltipProvider.module.scss
@@ -1,0 +1,58 @@
+.tooltip-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: min-content;
+  height: min-content;
+  text-align: center;
+}
+
+.tooltip {
+  position: relative;
+
+  &[data-tooltip] {
+    &:before {
+      display: flex;
+      visibility: hidden;
+      z-index: 3000;
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      align-items: center;
+      justify-content: center;
+
+      width: max-content;
+      max-width: 200px;
+      height: min-content;
+      min-height: 24px;
+      padding: 4px 8px;
+      transform: translateX(-50%) translateY(-4px);
+      border-radius: 4px;
+      background: var(--md-sys-color-inverse-surface);
+      content: attr(data-tooltip);
+
+      color: var(--md-sys-color-inverse-on-surface);
+      font-weight: 400;
+      font-size: 12px;
+      line-height: 16px;
+      letter-spacing: 0.4px;
+      white-space: pre-line;
+
+      opacity: 0;
+      transition: all 0.2s ease;
+    }
+
+    &:not([data-tooltip='']):hover {
+      &:before {
+        visibility: visible;
+        opacity: 1;
+      }
+    }
+  }
+
+  &.extra-gap {
+    &:before {
+      transform: translateX(-50%) translateY(-8px);
+    }
+  }
+}

--- a/frontend/src/components/Tooltips/TooltipProvider.tsx
+++ b/frontend/src/components/Tooltips/TooltipProvider.tsx
@@ -1,0 +1,24 @@
+import styles from './TooltipProvider.module.scss';
+
+const TooltipProvider = ({
+  children,
+  text,
+  extraGap
+}: {
+  children: React.ReactNode;
+  text: string;
+  extraGap?: boolean;
+}) => {
+  return (
+    <div className={styles['tooltip-wrap']}>
+      <div
+        className={`${styles['tooltip']} ${extraGap ? styles['extra-gap'] : ''}`}
+        data-tooltip={text}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default TooltipProvider;


### PR DESCRIPTION
https://m3.material.io/components/tooltips/overview

![image](https://github.com/user-attachments/assets/4192eb56-f4cc-4806-b97d-a80dfd918ef1)

- TooltipProvider의 hover시 상단에 Plain tooltip 표시
- TooltipProvider의 크기는 자식 요소와 같으므로 tooltip이 필요한 요소를 감싸 사용
- tooltip과 요소 간 시각적인 구분이 없을 경우 추가 간격 사용
  - TooltipProvider에 extraGap=true 전달
  - https://m3.material.io/components/tooltips/guidelines#57286ec2-db8e-4699-aa43-0ca11cab0bb5
- 사용 예시는 TooltipExample 참고