### PR TITLE
Update/scheme

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,8 @@
         "react-error-boundary": "^6.0.0",
         "react-redux": "^9.2.0",
         "redux": "^5.0.1",
-        "sass": "^1.83.4"
+        "sass": "^1.83.4",
+        "ts-fsrs": "^5.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5507,6 +5508,14 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-fsrs": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ts-fsrs/-/ts-fsrs-5.0.1.tgz",
+      "integrity": "sha512-Vlp6V0OLpgAv4/+ZmiKKbD3nD8sHKSJz5W7gtpFitTFMqTBt9nz/SOg+kPkhE/BdeMyXaIQEAp/mf7jDnnOUxQ==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "react-error-boundary": "^6.0.0",
     "react-redux": "^9.2.0",
     "redux": "^5.0.1",
-    "sass": "^1.83.4"
+    "sass": "^1.83.4",
+    "ts-fsrs": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,3 +1,4 @@
+import { TokenDTO } from '@/types/schemes';
 import { ApiError } from './utils';
 
 const endpoint = process.env.NEXT_PUBLIC_SERVER;
@@ -18,7 +19,7 @@ export const getToken = async (authenticationToken: string) => {
     const data = await response.json();
 
     if (response.ok) {
-      return data;
+      return data as TokenDTO;
     }
 
     throw new ApiError(response.status, '토큰 발급 실패', data);

--- a/frontend/src/api/cards.ts
+++ b/frontend/src/api/cards.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { Locale } from '../types/Locale';
-import { CardDetail, Card, Paginated } from '../types/schemes';
+import { KoreanCardDetail, Card, Paginated } from '../types/schemes';
 import { requestApi } from './utils';
 
 const endpoint = process.env.NEXT_PUBLIC_SERVER;
@@ -33,6 +33,6 @@ export const getCard = async (cardId: number, token: string) => {
 
 export const getCardDetail = async (cardId: number, token: string) => {
   const url = `${endpoint}/cards/${cardId}/details`;
-  const response = await requestApi<CardDetail>({ url, token });
+  const response = await requestApi<KoreanCardDetail>({ url, token });
   return response;
 };

--- a/frontend/src/api/cards.ts
+++ b/frontend/src/api/cards.ts
@@ -31,8 +31,8 @@ export const getCard = async (cardId: number, token: string) => {
   return response;
 };
 
-export const getCardDetail = async (cardId: number, token: string) => {
-  const url = `${endpoint}/cards/${cardId}/details`;
+export const getCardDetail = async (cardId: number, locale: Locale, token: string) => {
+  const url = `${endpoint}/cards/${cardId}/details?code=${locale}`;
   const response = await requestApi<KoreanCardDetail>({ url, token });
   return response;
 };

--- a/frontend/src/api/decks.ts
+++ b/frontend/src/api/decks.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { Locale } from '@/types/Locale';
-import { Paginated, CardDetail, UserStudyHistory, Deck } from '@/types/schemes';
+import { Paginated, KoreanCardDetail, UserStudyHistory, Deck } from '@/types/schemes';
 import { Category, getCategoryType } from '@/types/Category';
 import { requestApi, tryRefresh } from './utils';
 
@@ -18,7 +18,7 @@ export const getCardsFromDeck = async (locale: Locale, query: Category) => {
   const queryType = getCategoryType(query) === 'difficulty' ? 'level' : 'meaning';
   const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
 
-  const response = await requestApi<Paginated<CardDetail>>({ url });
+  const response = await requestApi<Paginated<KoreanCardDetail>>({ url });
   return response;
 };
 

--- a/frontend/src/api/decks.ts
+++ b/frontend/src/api/decks.ts
@@ -1,10 +1,10 @@
 'use server';
 
 import { Locale } from '@/types/Locale';
-import { Paginated, UserCardDTO, UserStudyHistory, Deck, KoreanCardDetail } from '@/types/schemes';
+import { Paginated, UserCardDTO, UserStudyHistory, Deck } from '@/types/schemes';
 import { Category, getCategoryType } from '@/types/Category';
 import { requestApi, tryRefresh } from './utils';
-import { toUserCard } from '@/utils/converter';
+import { toKoreanCardDetail, toUserCard } from '@/utils/converter';
 
 const endpoint = process.env.NEXT_PUBLIC_SERVER;
 
@@ -24,10 +24,14 @@ export const getUserCardsFromDeck = async (locale: Locale, query: Category) => {
   return { ...response, content: cards };
 };
 
-export const getKoreanCardDetailsFromDeck = async () => {
-  const url = 'not implemented';
-  const response = await requestApi<Paginated<KoreanCardDetail>>({ url });
-  return response;
+// API 미구현으로 인해 타입만 맞춰서 반환
+export const getKoreanCardDetailsFromDeck = async (locale: Locale, query: Category) => {
+  const queryType = getCategoryType(query) === 'difficulty' ? 'level' : 'meaning';
+  const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
+  const response = await requestApi<Paginated<UserCardDTO>>({ url });
+
+  const cards = response.content.map((card) => toKoreanCardDetail(card));
+  return { ...response, content: cards };
 };
 
 export const getUserStudyHistories = async (token: string) => {

--- a/frontend/src/api/decks.ts
+++ b/frontend/src/api/decks.ts
@@ -1,16 +1,10 @@
 'use server';
 
 import { Locale } from '@/types/Locale';
-import {
-  Paginated,
-  UserCardDTO,
-  UserStudyHistory,
-  Deck,
-  KoreanCardDetail,
-  convertUserCardDTOToUserCard
-} from '@/types/schemes';
+import { Paginated, UserCardDTO, UserStudyHistory, Deck, KoreanCardDetail } from '@/types/schemes';
 import { Category, getCategoryType } from '@/types/Category';
 import { requestApi, tryRefresh } from './utils';
+import { toUserCard } from '@/utils/converter';
 
 const endpoint = process.env.NEXT_PUBLIC_SERVER;
 
@@ -26,7 +20,7 @@ export const getUserCardsFromDeck = async (locale: Locale, query: Category) => {
   const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
 
   const response = await requestApi<Paginated<UserCardDTO>>({ url });
-  const cards = response.content.map((card) => convertUserCardDTOToUserCard(card));
+  const cards = response.content.map((card) => toUserCard(card));
   return { ...response, content: cards };
 };
 

--- a/frontend/src/api/decks.ts
+++ b/frontend/src/api/decks.ts
@@ -1,10 +1,10 @@
 'use server';
 
 import { Locale } from '@/types/Locale';
-import { Paginated, UserCardDTO, UserStudyHistory, Deck } from '@/types/schemes';
+import { Paginated, UserStudyHistory, Deck, KoreanCardWithForeignWords } from '@/types/schemes';
 import { Category, getCategoryType } from '@/types/Category';
 import { requestApi, tryRefresh } from './utils';
-import { normalizeQuery, toKoreanCardDetail, toUserCard } from '@/utils/converter';
+import { normalizeQuery } from '@/utils/converter';
 
 const endpoint = process.env.NEXT_PUBLIC_SERVER;
 
@@ -15,21 +15,11 @@ export const getDecks = async (queryType: 'difficulty' | 'meaning', token: strin
   return response;
 };
 
-export const getUserCardsFromDeck = async (locale: Locale, query: Category) => {
+export const getCardsFromDeck = async (locale: Locale, query: Category) => {
   const queryType = normalizeQuery(getCategoryType(query));
   const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${query}`;
-  const response = await requestApi<Paginated<UserCardDTO>>({ url });
-  const cards = response.content.map((card) => toUserCard(card));
-  return { ...response, content: cards };
-};
-
-// API 미구현으로 인해 타입만 맞춰서 반환
-export const getKoreanCardDetailsFromDeck = async (locale: Locale, query: Category) => {
-  const queryType = normalizeQuery(getCategoryType(query));
-  const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${query}`;
-  const response = await requestApi<Paginated<UserCardDTO>>({ url });
-  const cards = response.content.map((card) => toKoreanCardDetail(card));
-  return { ...response, content: cards };
+  const response = await requestApi<Paginated<KoreanCardWithForeignWords>>({ url });
+  return response;
 };
 
 export const getUserStudyHistories = async (token: string) => {

--- a/frontend/src/api/decks.ts
+++ b/frontend/src/api/decks.ts
@@ -2,7 +2,7 @@
 
 import { Locale } from '@/types/Locale';
 import { Paginated, UserCardDTO, UserStudyHistory, Deck } from '@/types/schemes';
-import { Category } from '@/types/Category';
+import { Category, getCategoryType } from '@/types/Category';
 import { requestApi, tryRefresh } from './utils';
 import { normalizeQuery, toKoreanCardDetail, toUserCard } from '@/utils/converter';
 
@@ -16,7 +16,8 @@ export const getDecks = async (queryType: 'difficulty' | 'meaning', token: strin
 };
 
 export const getUserCardsFromDeck = async (locale: Locale, query: Category) => {
-  const url = `${endpoint}/decks/cards?code=${locale}&queryType=${normalizeQuery(query)}&query=${query}`;
+  const queryType = normalizeQuery(getCategoryType(query));
+  const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${query}`;
   const response = await requestApi<Paginated<UserCardDTO>>({ url });
   const cards = response.content.map((card) => toUserCard(card));
   return { ...response, content: cards };
@@ -24,7 +25,8 @@ export const getUserCardsFromDeck = async (locale: Locale, query: Category) => {
 
 // API 미구현으로 인해 타입만 맞춰서 반환
 export const getKoreanCardDetailsFromDeck = async (locale: Locale, query: Category) => {
-  const url = `${endpoint}/decks/cards?code=${locale}&queryType=${normalizeQuery(query)}&query=${query}`;
+  const queryType = normalizeQuery(getCategoryType(query));
+  const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${query}`;
   const response = await requestApi<Paginated<UserCardDTO>>({ url });
   const cards = response.content.map((card) => toKoreanCardDetail(card));
   return { ...response, content: cards };

--- a/frontend/src/api/decks.ts
+++ b/frontend/src/api/decks.ts
@@ -1,7 +1,14 @@
 'use server';
 
 import { Locale } from '@/types/Locale';
-import { Paginated, KoreanCardDetail, UserStudyHistory, Deck } from '@/types/schemes';
+import {
+  Paginated,
+  UserCardDTO,
+  UserStudyHistory,
+  Deck,
+  KoreanCardDetail,
+  convertUserCardDTOToUserCard
+} from '@/types/schemes';
 import { Category, getCategoryType } from '@/types/Category';
 import { requestApi, tryRefresh } from './utils';
 
@@ -14,10 +21,17 @@ export const getDecks = async (queryType: 'difficulty' | 'meaning', token: strin
   return response;
 };
 
-export const getCardsFromDeck = async (locale: Locale, query: Category) => {
+export const getUserCardsFromDeck = async (locale: Locale, query: Category) => {
   const queryType = getCategoryType(query) === 'difficulty' ? 'level' : 'meaning';
   const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
 
+  const response = await requestApi<Paginated<UserCardDTO>>({ url });
+  const cards = response.content.map((card) => convertUserCardDTOToUserCard(card));
+  return { ...response, content: cards };
+};
+
+export const getKoreanCardDetailsFromDeck = async () => {
+  const url = 'not implemented';
   const response = await requestApi<Paginated<KoreanCardDetail>>({ url });
   return response;
 };

--- a/frontend/src/api/decks.ts
+++ b/frontend/src/api/decks.ts
@@ -2,22 +2,21 @@
 
 import { Locale } from '@/types/Locale';
 import { Paginated, UserCardDTO, UserStudyHistory, Deck } from '@/types/schemes';
-import { Category, getCategoryType } from '@/types/Category';
+import { Category } from '@/types/Category';
 import { requestApi, tryRefresh } from './utils';
-import { toKoreanCardDetail, toUserCard } from '@/utils/converter';
+import { normalizeQuery, toKoreanCardDetail, toUserCard } from '@/utils/converter';
 
 const endpoint = process.env.NEXT_PUBLIC_SERVER;
 
 export const getDecks = async (queryType: 'difficulty' | 'meaning', token: string) => {
   const accessToken = await tryRefresh(token);
-  const url = `${endpoint}/decks?queryType=${queryType === 'difficulty' ? 'level' : 'meaning'}`;
+  const url = `${endpoint}/decks?queryType=${normalizeQuery(queryType)}`;
   const response = await requestApi<Paginated<Deck>>({ url, token: accessToken ?? '' });
   return response;
 };
 
 export const getUserCardsFromDeck = async (locale: Locale, query: Category) => {
-  const queryType = getCategoryType(query) === 'difficulty' ? 'level' : 'meaning';
-  const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
+  const url = `${endpoint}/decks/cards?code=${locale}&queryType=${normalizeQuery(query)}&query=${query}`;
   const response = await requestApi<Paginated<UserCardDTO>>({ url });
   const cards = response.content.map((card) => toUserCard(card));
   return { ...response, content: cards };
@@ -25,8 +24,7 @@ export const getUserCardsFromDeck = async (locale: Locale, query: Category) => {
 
 // API 미구현으로 인해 타입만 맞춰서 반환
 export const getKoreanCardDetailsFromDeck = async (locale: Locale, query: Category) => {
-  const queryType = getCategoryType(query) === 'difficulty' ? 'level' : 'meaning';
-  const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
+  const url = `${endpoint}/decks/cards?code=${locale}&queryType=${normalizeQuery(query)}&query=${query}`;
   const response = await requestApi<Paginated<UserCardDTO>>({ url });
   const cards = response.content.map((card) => toKoreanCardDetail(card));
   return { ...response, content: cards };

--- a/frontend/src/api/decks.ts
+++ b/frontend/src/api/decks.ts
@@ -11,14 +11,13 @@ const endpoint = process.env.NEXT_PUBLIC_SERVER;
 export const getDecks = async (queryType: 'difficulty' | 'meaning', token: string) => {
   const accessToken = await tryRefresh(token);
   const url = `${endpoint}/decks?queryType=${queryType === 'difficulty' ? 'level' : 'meaning'}`;
-  const response = await requestApi<Paginated<Deck>>({ url, token: accessToken });
+  const response = await requestApi<Paginated<Deck>>({ url, token: accessToken ?? '' });
   return response;
 };
 
 export const getUserCardsFromDeck = async (locale: Locale, query: Category) => {
   const queryType = getCategoryType(query) === 'difficulty' ? 'level' : 'meaning';
   const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
-
   const response = await requestApi<Paginated<UserCardDTO>>({ url });
   const cards = response.content.map((card) => toUserCard(card));
   return { ...response, content: cards };
@@ -29,7 +28,6 @@ export const getKoreanCardDetailsFromDeck = async (locale: Locale, query: Catego
   const queryType = getCategoryType(query) === 'difficulty' ? 'level' : 'meaning';
   const url = `${endpoint}/decks/cards?code=${locale}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
   const response = await requestApi<Paginated<UserCardDTO>>({ url });
-
   const cards = response.content.map((card) => toKoreanCardDetail(card));
   return { ...response, content: cards };
 };

--- a/frontend/src/api/mock.ts
+++ b/frontend/src/api/mock.ts
@@ -3,7 +3,7 @@ import {
   Deck,
   Card,
   CardDetail,
-  CardStudyInfo,
+  StudyInfo,
   UserStudyHistory,
   UserOption,
   UserCard
@@ -13,13 +13,13 @@ import {
   DUMMY_CARD,
   DUMMY_CARDS,
   DUMMY_DECKS,
-  DUMMY_STUDY_CARD_FORM,
   DUMMY_USER_CARDS,
   DUMMY_USER_OPTION,
   DUMMY_USER_STUDY_HISTORIES,
   DUMMY_USER_STUDY_HISTORY,
   DUMMY_CARD_DETAIL,
-  DUMMY_CARD_STUDY_INFO
+  DUMMY_STUDY_INFO,
+  DUMMY_STUDY_INFO_DTO
 } from '@/utils/dummyData';
 
 export const mockForeignSearch = async () => {
@@ -73,9 +73,9 @@ export const mockGetUserCards = async () => {
 };
 
 export const mockGetCardStudyInfo = async () => {
-  return new Promise<CardStudyInfo>((resolve) => {
+  return new Promise<StudyInfo>((resolve) => {
     setTimeout(() => {
-      const data = DUMMY_CARD_STUDY_INFO;
+      const data = DUMMY_STUDY_INFO;
       console.log('mockGetCardStudyInfo:', data);
       resolve(data);
     }, 500);
@@ -85,7 +85,7 @@ export const mockGetCardStudyInfo = async () => {
 export const mockPostCardStudyInfo = async () => {
   return new Promise((resolve) => {
     setTimeout(() => {
-      const data = DUMMY_STUDY_CARD_FORM;
+      const data = DUMMY_STUDY_INFO_DTO;
       console.log('mockPostCardStudyInfo:', data);
       resolve(data);
     }, 500);

--- a/frontend/src/api/mock.ts
+++ b/frontend/src/api/mock.ts
@@ -6,7 +6,8 @@ import {
   StudyInfo,
   UserStudyHistory,
   UserOption,
-  UserCard
+  UserCard,
+  KoreanCardWithForeignWords
 } from '@/types/schemes';
 
 import {
@@ -19,8 +20,8 @@ import {
   DUMMY_USER_STUDY_HISTORY,
   DUMMY_STUDY_INFO,
   DUMMY_STUDY_INFO_DTO,
-  DUMMY_KOR_CARD_DETAILS,
-  DUMMY_KOR_CARD_DETAIL
+  DUMMY_KOR_CARD_DETAIL,
+  DUMMY_KOR_CARD_WITH_FOREIGN_WORDS
 } from '@/utils/dummyData';
 
 export const mockForeignSearch = async () => {
@@ -103,25 +104,21 @@ export const mockGetDecks = async (queryType: 'level' | 'meaning') => {
   });
 };
 
-export const mockGetUserCardsFromDeck = async () => {
-  return new Promise<Paginated<UserCard>>((resolve) => {
+export const mockGetCardsFromDeck = async () => {
+  return new Promise<Paginated<KoreanCardWithForeignWords>>((resolve) => {
     setTimeout(() => {
-      const data = DUMMY_USER_CARDS;
+      const data = {
+        content: [DUMMY_KOR_CARD_WITH_FOREIGN_WORDS],
+        page: 1,
+        pageSize: 10,
+        size: 1
+      };
       console.log('mockGetCardsFromDeck:', data);
       resolve(data);
     }, 500);
   });
 };
 
-export const mockGetKoreanCardDetailsFromDeck = async () => {
-  return new Promise<Paginated<KoreanCardDetail>>((resolve) => {
-    setTimeout(() => {
-      const data = DUMMY_KOR_CARD_DETAILS;
-      console.log('mockGetCardsFromDeck:', data);
-      resolve(data);
-    }, 500);
-  });
-};
 export const mockGetUserStudyHistories = async () => {
   return new Promise<Paginated<UserStudyHistory>>((resolve) => {
     setTimeout(() => {

--- a/frontend/src/api/mock.ts
+++ b/frontend/src/api/mock.ts
@@ -17,9 +17,10 @@ import {
   DUMMY_USER_OPTION,
   DUMMY_USER_STUDY_HISTORIES,
   DUMMY_USER_STUDY_HISTORY,
-  DUMMY_CARD_DETAIL,
   DUMMY_STUDY_INFO,
-  DUMMY_STUDY_INFO_DTO
+  DUMMY_STUDY_INFO_DTO,
+  DUMMY_KOR_CARD_DETAILS,
+  DUMMY_KOR_CARD_DETAIL
 } from '@/utils/dummyData';
 
 export const mockForeignSearch = async () => {
@@ -55,7 +56,7 @@ export const mockGetCard = async () => {
 export const mockGetCardDetail = async () => {
   return new Promise<KoreanCardDetail>((resolve) => {
     setTimeout(() => {
-      const data = DUMMY_CARD_DETAIL;
+      const data = DUMMY_KOR_CARD_DETAIL;
       console.log('mockGetCardDetail:', data);
       resolve(data);
     }, 500);
@@ -102,16 +103,25 @@ export const mockGetDecks = async (queryType: 'level' | 'meaning') => {
   });
 };
 
-export const mockGetCardsFromDeck = async () => {
-  return new Promise<Paginated<Card>>((resolve) => {
+export const mockGetUserCardsFromDeck = async () => {
+  return new Promise<Paginated<UserCard>>((resolve) => {
     setTimeout(() => {
-      const data = DUMMY_CARDS;
+      const data = DUMMY_USER_CARDS;
       console.log('mockGetCardsFromDeck:', data);
       resolve(data);
     }, 500);
   });
 };
 
+export const mockGetKoreanCardDetailsFromDeck = async () => {
+  return new Promise<Paginated<KoreanCardDetail>>((resolve) => {
+    setTimeout(() => {
+      const data = DUMMY_KOR_CARD_DETAILS;
+      console.log('mockGetCardsFromDeck:', data);
+      resolve(data);
+    }, 500);
+  });
+};
 export const mockGetUserStudyHistories = async () => {
   return new Promise<Paginated<UserStudyHistory>>((resolve) => {
     setTimeout(() => {

--- a/frontend/src/api/mock.ts
+++ b/frontend/src/api/mock.ts
@@ -2,7 +2,7 @@ import {
   Paginated,
   Deck,
   Card,
-  CardDetail,
+  KoreanCardDetail,
   StudyInfo,
   UserStudyHistory,
   UserOption,
@@ -53,7 +53,7 @@ export const mockGetCard = async () => {
 };
 
 export const mockGetCardDetail = async () => {
-  return new Promise<CardDetail>((resolve) => {
+  return new Promise<KoreanCardDetail>((resolve) => {
     setTimeout(() => {
       const data = DUMMY_CARD_DETAIL;
       console.log('mockGetCardDetail:', data);

--- a/frontend/src/api/study.ts
+++ b/frontend/src/api/study.ts
@@ -1,15 +1,15 @@
 'use server';
 
 import { Paginated, StudyType, StudyInfo, StudyInfoDTO, UserCardDTO } from '@/types/schemes';
-import { Category } from '@/types/Category';
+import { Category, getCategoryType } from '@/types/Category';
 import { requestApi } from './utils';
 import { normalizeQuery, toStudyInfo, toStudyInfoDTO, toUserCard } from '@/utils/converter';
 
 const endpoint = process.env.NEXT_PUBLIC_SERVER;
 
 export const getUserCards = async (studyType: StudyType, query: Category, token: string) => {
-  const url = `${endpoint}/cards/study?studyType=${normalizeQuery(studyType)}&queryType=${normalizeQuery(query)}&query=${query}`;
-  console.log('LOGGING: url', url);
+  const queryType = normalizeQuery(getCategoryType(query));
+  const url = `${endpoint}/cards/study?studyType=${normalizeQuery(studyType)}&queryType=${queryType}&query=${query}`;
 
   const response = await requestApi<Paginated<UserCardDTO>>({ url, token });
 

--- a/frontend/src/api/study.ts
+++ b/frontend/src/api/study.ts
@@ -7,7 +7,7 @@ import { normalizeQuery, toStudyInfo, toStudyInfoDTO, toUserCard } from '@/utils
 
 const endpoint = process.env.NEXT_PUBLIC_SERVER;
 
-export const getUserCards = async (studyType: StudyType, query: Category, token: string) => {
+export const getLearningCards = async (studyType: StudyType, query: Category, token: string) => {
   const queryType = normalizeQuery(getCategoryType(query));
   const url = `${endpoint}/cards/study?studyType=${normalizeQuery(studyType)}&queryType=${queryType}&query=${query}`;
 
@@ -21,14 +21,14 @@ export const getUserCards = async (studyType: StudyType, query: Category, token:
   };
 };
 
-export const getCardStudyInfo = async (cardId: number, token: string) => {
+export const getStudyInfo = async (cardId: number, token: string) => {
   const url = `${endpoint}/cards/${cardId}/study`;
   const data = await requestApi<StudyInfoDTO>({ url, token });
   const convertedData = toStudyInfo(data);
   return convertedData;
 };
 
-export const postCardStudyInfo = async (cardId: number, studyInfo: StudyInfo, token: string) => {
+export const postStudyInfo = async (cardId: number, studyInfo: StudyInfo, token: string) => {
   const url = `${endpoint}/cards/${cardId}/study`;
   const data = await requestApi<StudyInfoDTO>({
     url,

--- a/frontend/src/api/study.ts
+++ b/frontend/src/api/study.ts
@@ -1,15 +1,9 @@
 'use server';
 
-import {
-  Paginated,
-  StudyType,
-  StudyInfo,
-  StudyInfoDTO,
-  UserCardDTO,
-  convertUserCardDTOToUserCard
-} from '@/types/schemes';
+import { Paginated, StudyType, StudyInfo, StudyInfoDTO, UserCardDTO } from '@/types/schemes';
 import { Category, getCategoryType } from '@/types/Category';
 import { requestApi } from './utils';
+import { toStudyInfo, toStudyInfoDTO, toUserCard } from '@/utils/converter';
 
 const endpoint = process.env.NEXT_PUBLIC_SERVER;
 
@@ -22,7 +16,7 @@ export const getUserCards = async (studyType: StudyType, query: Category, token:
 
   const response = await requestApi<Paginated<UserCardDTO>>({ url, token });
 
-  const convertedData = response.content.map((card) => convertUserCardDTOToUserCard(card));
+  const convertedData = response.content.map((card) => toUserCard(card));
 
   return {
     ...response,
@@ -32,17 +26,19 @@ export const getUserCards = async (studyType: StudyType, query: Category, token:
 
 export const getCardStudyInfo = async (cardId: number, token: string) => {
   const url = `${endpoint}/cards/${cardId}/study`;
-  const response = await requestApi<StudyInfo>({ url, token });
-  return response;
+  const data = await requestApi<StudyInfoDTO>({ url, token });
+  const convertedData = toStudyInfo(data);
+  return convertedData;
 };
 
-export const postCardStudyInfo = async (cardId: number, studyInfo: StudyInfoDTO, token: string) => {
+export const postCardStudyInfo = async (cardId: number, studyInfo: StudyInfo, token: string) => {
   const url = `${endpoint}/cards/${cardId}/study`;
-  const response = await requestApi<StudyInfo>({
+  const data = await requestApi<StudyInfoDTO>({
     url,
     token,
     method: 'POST',
-    body: studyInfo
+    body: toStudyInfoDTO(studyInfo)
   });
-  return response;
+  const convertedData = toStudyInfo(data);
+  return convertedData;
 };

--- a/frontend/src/api/study.ts
+++ b/frontend/src/api/study.ts
@@ -1,18 +1,14 @@
 'use server';
 
 import { Paginated, StudyType, StudyInfo, StudyInfoDTO, UserCardDTO } from '@/types/schemes';
-import { Category, getCategoryType } from '@/types/Category';
+import { Category } from '@/types/Category';
 import { requestApi } from './utils';
-import { toStudyInfo, toStudyInfoDTO, toUserCard } from '@/utils/converter';
+import { normalizeQuery, toStudyInfo, toStudyInfoDTO, toUserCard } from '@/utils/converter';
 
 const endpoint = process.env.NEXT_PUBLIC_SERVER;
 
 export const getUserCards = async (studyType: StudyType, query: Category, token: string) => {
-  const queryStudyType = studyType === 'new' ? 'study' : 'review';
-
-  const queryType = getCategoryType(query) === 'difficulty' ? 'level' : 'meaning';
-
-  const url = `${endpoint}/cards/study?studyType=${queryStudyType}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
+  const url = `${endpoint}/cards/study?studyType=${normalizeQuery(studyType)}&queryType=${normalizeQuery(query)}&query=${query}`;
   console.log('LOGGING: url', url);
 
   const response = await requestApi<Paginated<UserCardDTO>>({ url, token });

--- a/frontend/src/api/study.ts
+++ b/frontend/src/api/study.ts
@@ -3,10 +3,10 @@
 import {
   Paginated,
   StudyType,
-  CardStudyInfo,
-  StudyCardForm,
-  UserCardServerResponse,
-  convertUserCardServerResponseToUserCard
+  StudyInfo,
+  StudyInfoDTO,
+  UserCardDTO,
+  convertUserCardDTOToUserCard
 } from '@/types/schemes';
 import { Category, getCategoryType } from '@/types/Category';
 import { requestApi } from './utils';
@@ -20,11 +20,9 @@ export const getUserCards = async (studyType: StudyType, query: Category, token:
 
   const url = `${endpoint}/cards/study?studyType=${queryStudyType}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
 
-  const response = await requestApi<Paginated<UserCardServerResponse>>({ url, token });
+  const response = await requestApi<Paginated<UserCardDTO>>({ url, token });
 
-  const convertedData = response.content.map((card) =>
-    convertUserCardServerResponseToUserCard(card)
-  );
+  const convertedData = response.content.map((card) => convertUserCardDTOToUserCard(card));
 
   return {
     ...response,
@@ -34,21 +32,17 @@ export const getUserCards = async (studyType: StudyType, query: Category, token:
 
 export const getCardStudyInfo = async (cardId: number, token: string) => {
   const url = `${endpoint}/cards/${cardId}/study`;
-  const response = await requestApi<CardStudyInfo>({ url, token });
+  const response = await requestApi<StudyInfo>({ url, token });
   return response;
 };
 
-export const postCardStudyInfo = async (
-  cardId: number,
-  studyCardForm: StudyCardForm,
-  token: string
-) => {
+export const postCardStudyInfo = async (cardId: number, studyInfo: StudyInfoDTO, token: string) => {
   const url = `${endpoint}/cards/${cardId}/study`;
-  const response = await requestApi<CardStudyInfo>({
+  const response = await requestApi<StudyInfo>({
     url,
     token,
     method: 'POST',
-    body: studyCardForm
+    body: studyInfo
   });
   return response;
 };

--- a/frontend/src/api/study.ts
+++ b/frontend/src/api/study.ts
@@ -13,6 +13,7 @@ export const getUserCards = async (studyType: StudyType, query: Category, token:
   const queryType = getCategoryType(query) === 'difficulty' ? 'level' : 'meaning';
 
   const url = `${endpoint}/cards/study?studyType=${queryStudyType}&queryType=${queryType}&query=${queryType === 'level' ? query : query.toUpperCase()}`;
+  console.log('LOGGING: url', url);
 
   const response = await requestApi<Paginated<UserCardDTO>>({ url, token });
 

--- a/frontend/src/app/[locale]/auth/redirect/page.tsx
+++ b/frontend/src/app/[locale]/auth/redirect/page.tsx
@@ -22,8 +22,8 @@ export default function GoogleLoginRedirectPage() {
     (async function () {
       console.log(authenticationToken);
       if (authenticationToken) {
-        const { accessToken, refreshToken, setup } = await getToken(authenticationToken);
-        console.log('getToken:', { accessToken, refreshToken, setup });
+        const { accessToken, refreshToken, isSetup } = await getToken(authenticationToken);
+        console.log('getToken:', { accessToken, refreshToken, isSetup });
 
         // accessToken을 store에 저장
         dispatch(setAccessToken(accessToken));
@@ -31,7 +31,7 @@ export default function GoogleLoginRedirectPage() {
         setCookie({ name: 'refreshToken', value: refreshToken });
 
         // 유저의 옵션 상태에 따라 리디렉션
-        if (setup) {
+        if (isSetup) {
           redirect('/difficulty');
         } else {
           redirect('/settings');

--- a/frontend/src/app/[locale]/difficulty/[category]/page.tsx
+++ b/frontend/src/app/[locale]/difficulty/[category]/page.tsx
@@ -3,21 +3,21 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 
-import { getKoreanCardDetailsFromDeck } from '@/api/decks';
+import { getCardsFromDeck } from '@/api/decks';
 import WordListPage from '@/components/common/WordListPage';
 
-import { KoreanCardDetail, Paginated } from '@/types/schemes';
+import { KoreanCardWithForeignWords, Paginated } from '@/types/schemes';
 import { Category } from '@/types/Category';
 import { Locale } from '@/types/Locale';
 
 export default function DifficultyWordsPage() {
   const { category, locale } = useParams() ?? {};
 
-  const [userCards, setUserCards] = useState<Paginated<KoreanCardDetail>>();
+  const [userCards, setUserCards] = useState<Paginated<KoreanCardWithForeignWords>>();
 
   useEffect(() => {
     const fetchUserCards = async () => {
-      const cards = await getKoreanCardDetailsFromDeck(locale as Locale, category as Category);
+      const cards = await getCardsFromDeck(locale as Locale, category as Category);
       if (cards) {
         setUserCards(cards);
       }

--- a/frontend/src/app/[locale]/difficulty/[category]/page.tsx
+++ b/frontend/src/app/[locale]/difficulty/[category]/page.tsx
@@ -3,11 +3,10 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 
-import { getCardsFromDeck } from '@/api/decks';
+import { getKoreanCardDetailsFromDeck } from '@/api/decks';
 import WordListPage from '@/components/common/WordListPage';
 
 import { KoreanCardDetail, Paginated } from '@/types/schemes';
-import { Locale } from '@/types/Locale';
 import { Category } from '@/types/Category';
 
 export default function DifficultyWordsPage() {
@@ -17,7 +16,7 @@ export default function DifficultyWordsPage() {
 
   useEffect(() => {
     const fetchUserCards = async () => {
-      const cards = await getCardsFromDeck(locale as Locale, category as Category);
+      const cards = await getKoreanCardDetailsFromDeck();
       if (cards) {
         setUserCards(cards);
       }

--- a/frontend/src/app/[locale]/difficulty/[category]/page.tsx
+++ b/frontend/src/app/[locale]/difficulty/[category]/page.tsx
@@ -8,6 +8,7 @@ import WordListPage from '@/components/common/WordListPage';
 
 import { KoreanCardDetail, Paginated } from '@/types/schemes';
 import { Category } from '@/types/Category';
+import { Locale } from '@/types/Locale';
 
 export default function DifficultyWordsPage() {
   const { category, locale } = useParams() ?? {};
@@ -16,7 +17,7 @@ export default function DifficultyWordsPage() {
 
   useEffect(() => {
     const fetchUserCards = async () => {
-      const cards = await getKoreanCardDetailsFromDeck();
+      const cards = await getKoreanCardDetailsFromDeck(locale as Locale, category as Category);
       if (cards) {
         setUserCards(cards);
       }

--- a/frontend/src/app/[locale]/difficulty/[category]/page.tsx
+++ b/frontend/src/app/[locale]/difficulty/[category]/page.tsx
@@ -6,14 +6,14 @@ import { useParams } from 'next/navigation';
 import { getCardsFromDeck } from '@/api/decks';
 import WordListPage from '@/components/common/WordListPage';
 
-import { CardDetail, Paginated } from '@/types/schemes';
+import { KoreanCardDetail, Paginated } from '@/types/schemes';
 import { Locale } from '@/types/Locale';
 import { Category } from '@/types/Category';
 
 export default function DifficultyWordsPage() {
   const { category, locale } = useParams() ?? {};
 
-  const [userCards, setUserCards] = useState<Paginated<CardDetail>>();
+  const [userCards, setUserCards] = useState<Paginated<KoreanCardDetail>>();
 
   useEffect(() => {
     const fetchUserCards = async () => {

--- a/frontend/src/app/[locale]/learning/[category]/page.tsx
+++ b/frontend/src/app/[locale]/learning/[category]/page.tsx
@@ -19,20 +19,13 @@ import { useTranslations } from 'next-intl';
 
 export default function LearningPage() {
   const t = useTranslations();
-
   const { category } = useParams() ?? {};
-
   const [contentHeight, setContentHeight] = useState(0);
-
   const [cardWidth, setCardWidth] = useState(0);
-
-  useEffect(() => {
-    setCardWidth(document.querySelector(`.${styles['learning-card']}`)?.scrollWidth ?? 0);
-  }, []);
 
   const [cardState, setCardState] = useState<LearningCardState>({
     isRevealed: false,
-    showDetail: false,
+    showDetail: true,
     showConjugation: false,
     showExample: false,
     isKoreanToForeign: true
@@ -43,24 +36,9 @@ export default function LearningPage() {
     cardWidth
   });
 
-  const { currentCard, currentCardDetail, studyQueue, intervalPreview, repeat, error } =
-    useStudyQueue(category as Category);
-
-  useEffect(() => {
-    if (error) {
-      console.error('error:', error);
-    }
-  }, [error]);
-
-  if (error) throw error;
-
-  if (studyQueue === null) {
-    return <div className={styles['page']}>Loading...</div>;
-  }
-
-  if (currentCard === null) {
-    return <div className={styles['page']}>학습 끝</div>;
-  }
+  const { currentCardDetail, studyQueue, intervalPreview, repeat, error } = useStudyQueue(
+    category as Category
+  );
 
   const handleReveal = () => {
     setCardState((prev) => ({ ...prev, isRevealed: true }));
@@ -116,8 +94,28 @@ export default function LearningPage() {
       : [])
   ];
 
-  if (currentCardDetail === null) {
+  useEffect(() => {
+    console.log('currentCardDetail', currentCardDetail);
+  }, [currentCardDetail]);
+
+  useEffect(() => {
+    setCardWidth(document.querySelector(`.${styles['learning-card']}`)?.scrollWidth ?? 0);
+  }, []);
+
+  useEffect(() => {
+    if (error) {
+      console.error('error:', error);
+    }
+  }, [error]);
+
+  if (error) throw error;
+
+  if (studyQueue === null) {
     return <div className={styles['page']}>Loading...</div>;
+  }
+
+  if (currentCardDetail === null) {
+    return <div className={styles['page']}>학습 끝</div>;
   }
 
   return (

--- a/frontend/src/app/[locale]/learning/[category]/page.tsx
+++ b/frontend/src/app/[locale]/learning/[category]/page.tsx
@@ -43,9 +43,8 @@ export default function LearningPage() {
     cardWidth
   });
 
-  const { currentCard, studyQueue, intervalPreview, repeat, error } = useStudyQueue(
-    category as Category
-  );
+  const { currentCard, currentCardDetail, studyQueue, intervalPreview, repeat, error } =
+    useStudyQueue(category as Category);
 
   useEffect(() => {
     if (error) {
@@ -117,6 +116,10 @@ export default function LearningPage() {
       : [])
   ];
 
+  if (currentCardDetail === null) {
+    return <div className={styles['page']}>Loading...</div>;
+  }
+
   return (
     <div className={styles['learning-container']}>
       <div className={styles['progress-container-wrapper']}>
@@ -125,7 +128,7 @@ export default function LearningPage() {
         </div>
       </div>
       <LearningCard
-        card={currentCard}
+        card={currentCardDetail}
         className={styles['learning-card']}
         cardState={cardState}
         handleReveal={handleReveal}

--- a/frontend/src/app/[locale]/meaning/[category]/page.tsx
+++ b/frontend/src/app/[locale]/meaning/[category]/page.tsx
@@ -8,12 +8,12 @@ import WordListPage from '@/components/common/WordListPage';
 
 import { Locale } from '@/types/Locale';
 import { Category } from '@/types/Category';
-import { CardDetail, Paginated } from '@/types/schemes';
+import { KoreanCardDetail, Paginated } from '@/types/schemes';
 
 export default function MeaningWordsPage() {
   const { category, locale } = useParams() ?? {};
 
-  const [userCards, setUserCards] = useState<Paginated<CardDetail>>();
+  const [userCards, setUserCards] = useState<Paginated<KoreanCardDetail>>();
 
   useEffect(() => {
     const fetchUserCards = async () => {

--- a/frontend/src/app/[locale]/meaning/[category]/page.tsx
+++ b/frontend/src/app/[locale]/meaning/[category]/page.tsx
@@ -3,21 +3,21 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 
-import { getKoreanCardDetailsFromDeck } from '@/api/decks';
+import { getCardsFromDeck } from '@/api/decks';
 import WordListPage from '@/components/common/WordListPage';
 
 import { Category } from '@/types/Category';
-import { KoreanCardDetail, Paginated } from '@/types/schemes';
+import { KoreanCardWithForeignWords, Paginated } from '@/types/schemes';
 import { Locale } from '@/types/Locale';
 
 export default function MeaningWordsPage() {
   const { category, locale } = useParams() ?? {};
 
-  const [userCards, setUserCards] = useState<Paginated<KoreanCardDetail>>();
+  const [userCards, setUserCards] = useState<Paginated<KoreanCardWithForeignWords>>();
 
   useEffect(() => {
     const fetchUserCards = async () => {
-      const cards = await getKoreanCardDetailsFromDeck(locale as Locale, category as Category);
+      const cards = await getCardsFromDeck(locale as Locale, category as Category);
       if (cards) {
         setUserCards(cards);
       }

--- a/frontend/src/app/[locale]/meaning/[category]/page.tsx
+++ b/frontend/src/app/[locale]/meaning/[category]/page.tsx
@@ -3,10 +3,9 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 
-import { getCardsFromDeck } from '@/api/decks';
+import { getKoreanCardDetailsFromDeck } from '@/api/decks';
 import WordListPage from '@/components/common/WordListPage';
 
-import { Locale } from '@/types/Locale';
 import { Category } from '@/types/Category';
 import { KoreanCardDetail, Paginated } from '@/types/schemes';
 
@@ -17,7 +16,7 @@ export default function MeaningWordsPage() {
 
   useEffect(() => {
     const fetchUserCards = async () => {
-      const cards = await getCardsFromDeck(locale as Locale, category as Category);
+      const cards = await getKoreanCardDetailsFromDeck();
       if (cards) {
         setUserCards(cards);
       }

--- a/frontend/src/app/[locale]/meaning/[category]/page.tsx
+++ b/frontend/src/app/[locale]/meaning/[category]/page.tsx
@@ -8,6 +8,7 @@ import WordListPage from '@/components/common/WordListPage';
 
 import { Category } from '@/types/Category';
 import { KoreanCardDetail, Paginated } from '@/types/schemes';
+import { Locale } from '@/types/Locale';
 
 export default function MeaningWordsPage() {
   const { category, locale } = useParams() ?? {};
@@ -16,7 +17,7 @@ export default function MeaningWordsPage() {
 
   useEffect(() => {
     const fetchUserCards = async () => {
-      const cards = await getKoreanCardDetailsFromDeck();
+      const cards = await getKoreanCardDetailsFromDeck(locale as Locale, category as Category);
       if (cards) {
         setUserCards(cards);
       }

--- a/frontend/src/components/LearningCard/ConjugationSection.tsx
+++ b/frontend/src/components/LearningCard/ConjugationSection.tsx
@@ -3,16 +3,16 @@ import styles from './ConjugationSection.module.scss';
 import { useTranslations } from 'next-intl';
 
 const PredicateConjugationLabels = [
-  { key: 'pastParticiple', lable: 'Past participle' },
-  { key: 'connective', lable: 'Connective' },
-  { key: 'seqConnect', lable: 'Sequential connective' },
-  { key: 'formalPresent', lable: 'Formal polite present' }
+  { key: 'pastParticiple', label: 'Past participle' },
+  { key: 'connective', label: 'Connective' },
+  { key: 'seqConnect', label: 'Sequential connective' },
+  { key: 'formalPresent', label: 'Formal polite present' }
 ];
 
 const NounConjugationLabels = [
-  { key: 'subjectMarker', lable: 'Subject marker' },
-  { key: 'alsoTooParticle', lable: 'Also/too particle' },
-  { key: 'onlyJustParticle', lable: 'Only/just particle' }
+  { key: 'subjectMarker', label: 'Subject marker' },
+  { key: 'alsoTooParticle', label: 'Also/too particle' },
+  { key: 'onlyJustParticle', label: 'Only/just particle' }
 ];
 
 interface ConjugationSectionProps {
@@ -37,9 +37,7 @@ const ConjugationSection = ({
         <IconButton onClick={toggleExpanded}>
           <Icon>{isExpanded ? 'arrow_drop_up' : 'arrow_drop_down'}</Icon>
         </IconButton>
-        <span className={styles['conjugations-header-title']}>
-          {t('learning.conjugations')}
-        </span>
+        <span className={styles['conjugations-header-title']}>{t('learning.conjugations')}</span>
       </div>
       {isExpanded && (
         <div className={styles['conjugations-list']}>

--- a/frontend/src/components/LearningCard/LearningCard.tsx
+++ b/frontend/src/components/LearningCard/LearningCard.tsx
@@ -63,6 +63,10 @@ const LearningCard = ({
     setContentHeight(height);
   }, [cardState, setContentHeight]);
 
+  useEffect(() => {
+    console.log('inflection', card.meanings[0]);
+  }, [card]);
+
   return (
     <FilledCard
       className={classNames(styles['learning-card'], className)}
@@ -73,7 +77,7 @@ const LearningCard = ({
       {!cardState.isRevealed && (
         <div className={styles['content-container']}>
           <span className={styles['korean-word']}>
-            {cardState.isKoreanToForeign ? card.koreanWord : card.meanings.foreignWord}
+            {cardState.isKoreanToForeign ? card.koreanWord : card.meanings[0].foreignWord}
           </span>
           <span className={classNames(styles['foreign-word'], styles['revealed'])}>
             {t('learning.checkAnswer')}
@@ -84,10 +88,10 @@ const LearningCard = ({
       {cardState.isRevealed && !cardState.showDetail && (
         <div className={styles['content-container']}>
           <span className={styles['korean-word']}>
-            {cardState.isKoreanToForeign ? card.koreanWord : card.meanings.foreignWord}
+            {cardState.isKoreanToForeign ? card.koreanWord : card.meanings[0].foreignWord}
           </span>
           <span className={styles['foreign-word']}>
-            {cardState.isKoreanToForeign ? card.meanings.foreignWord : card.koreanWord}
+            {cardState.isKoreanToForeign ? card.meanings[0].foreignWord : card.koreanWord}
           </span>
         </div>
       )}
@@ -97,12 +101,12 @@ const LearningCard = ({
           <WordSection card={card} />
           <div>
             <ConjugationSection
-              conjugations={card.meanings.inflection.split(', ')}
+              conjugations={card.meanings[0]?.inflection?.split(', ') ?? []}
               toggleExpanded={toggleConjugation}
               isExpanded={cardState.showConjugation}
             />
             <ExampleSection
-              examples={card.meanings.exampleUsage.trim().split('\n')}
+              examples={card.meanings[0]?.exampleUsage?.trim().split('\n') ?? []}
               toggleExpanded={toggleExample}
               isExpanded={cardState.showExample}
             />

--- a/frontend/src/components/LearningCard/LearningCard.tsx
+++ b/frontend/src/components/LearningCard/LearningCard.tsx
@@ -15,8 +15,6 @@ import { MenuItem as MenuItemType } from '@/types/Menu';
 import { useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 
-import { DUMMY_CARD_DETAIL } from '@/utils/dummyData';
-
 export interface LearningCardState {
   isRevealed: boolean;
   showDetail: boolean;

--- a/frontend/src/components/LearningCard/LearningCard.tsx
+++ b/frontend/src/components/LearningCard/LearningCard.tsx
@@ -1,5 +1,5 @@
 import { FilledCard } from '../Card/Card';
-import { UserCard } from '@/types/schemes';
+import { KoreanCardDetail } from '@/types/schemes';
 
 import styles from './LearningCard.module.scss';
 import classNames from 'classnames';
@@ -24,7 +24,7 @@ export interface LearningCardState {
 }
 
 interface LearningCardProps {
-  card: UserCard;
+  card: KoreanCardDetail;
   className?: string;
   style?: React.CSSProperties;
   cardState: LearningCardState;
@@ -73,7 +73,7 @@ const LearningCard = ({
       {!cardState.isRevealed && (
         <div className={styles['content-container']}>
           <span className={styles['korean-word']}>
-            {cardState.isKoreanToForeign ? card.koreanWord : card.foreignWord}
+            {cardState.isKoreanToForeign ? card.koreanWord : card.meanings.foreignWord}
           </span>
           <span className={classNames(styles['foreign-word'], styles['revealed'])}>
             {t('learning.checkAnswer')}
@@ -84,10 +84,10 @@ const LearningCard = ({
       {cardState.isRevealed && !cardState.showDetail && (
         <div className={styles['content-container']}>
           <span className={styles['korean-word']}>
-            {cardState.isKoreanToForeign ? card.koreanWord : card.foreignWord}
+            {cardState.isKoreanToForeign ? card.koreanWord : card.meanings.foreignWord}
           </span>
           <span className={styles['foreign-word']}>
-            {cardState.isKoreanToForeign ? card.foreignWord : card.koreanWord}
+            {cardState.isKoreanToForeign ? card.meanings.foreignWord : card.koreanWord}
           </span>
         </div>
       )}
@@ -97,12 +97,12 @@ const LearningCard = ({
           <WordSection card={card} />
           <div>
             <ConjugationSection
-              conjugations={card.inflection.split(', ')}
+              conjugations={card.meanings.inflection.split(', ')}
               toggleExpanded={toggleConjugation}
               isExpanded={cardState.showConjugation}
             />
             <ExampleSection
-              examples={card.exampleUsage.trim().split('\n')}
+              examples={card.meanings.exampleUsage.trim().split('\n')}
               toggleExpanded={toggleExample}
               isExpanded={cardState.showExample}
             />

--- a/frontend/src/components/LearningCard/WordSection.tsx
+++ b/frontend/src/components/LearningCard/WordSection.tsx
@@ -21,7 +21,7 @@ const WordSection = ({ card }: WordSectionProps) => {
     <>
       <div className={styles['korean-container']}>
         <span className={styles['korean-word']}>{card.koreanWord}</span>
-        <span className={styles['korean-homograph-number']}>{card.homographNumber}</span>
+        <span className={styles['korean-homograph-number']}>{+card.homographNumber + 1}</span>
         <div className={styles['korean-info-container']}>
           <span className={styles['korean-level']}>{levelLabel}</span>
           <div className={styles['korean-info-sub-container']}>

--- a/frontend/src/components/LearningCard/WordSection.tsx
+++ b/frontend/src/components/LearningCard/WordSection.tsx
@@ -13,7 +13,7 @@ interface WordSectionProps {
 }
 
 const WordSection = ({ card }: WordSectionProps) => {
-  const levelLabel = levelStars[card.level as keyof typeof levelStars] || '';
+  const levelLabel = levelStars[card.difficulty as keyof typeof levelStars] || '';
 
   return (
     <>

--- a/frontend/src/components/LearningCard/WordSection.tsx
+++ b/frontend/src/components/LearningCard/WordSection.tsx
@@ -1,11 +1,12 @@
 import { KoreanCardDetail } from '@/types/schemes';
 
 import styles from './WordSection.module.scss';
+import { Fragment } from 'react';
 
 const levelStars = {
-  beginner: '★★★',
-  intermediate: '★★',
-  advanced: '★'
+  easy: '★★★',
+  medium: '★★',
+  hard: '★'
 };
 
 interface WordSectionProps {
@@ -13,6 +14,7 @@ interface WordSectionProps {
 }
 
 const WordSection = ({ card }: WordSectionProps) => {
+  console.log('level', card.level);
   const levelLabel = levelStars[card.level as keyof typeof levelStars] || '';
 
   return (
@@ -23,17 +25,22 @@ const WordSection = ({ card }: WordSectionProps) => {
         <div className={styles['korean-info-container']}>
           <span className={styles['korean-level']}>{levelLabel}</span>
           <div className={styles['korean-info-sub-container']}>
-            <span className={styles['pronunciation']}>{`[${card.meanings.pronunciation}]`}</span>
-            <span className={styles['origin']}>{card.meanings.originalLanguage ?? ''}</span>
+            <span className={styles['pronunciation']}>{`[${card.meanings[0].pronunciation}]`}</span>
+            <span className={styles['origin']}>{card.meanings[0].originalLanguage ?? ''}</span>
           </div>
         </div>
       </div>
-      <div className={styles['foreign-container']}>
-        <span className={styles['foreign-word']}>
-          1. {card.meanings.partsOfSpeech} {card.meanings.foreignWord}
-        </span>
-        <span className={styles['foreign-word-sub']}>{card.meanings.relatedWords}</span>
-      </div>
+      {card.meanings.map((meaning, index) => (
+        <Fragment key={`${card.koreanWord}-${index}`}>
+          <div className={styles['foreign-container']}>
+            <span className={styles['foreign-word']}>
+              {index + 1}. {meaning.partsOfSpeech} {meaning.foreignWord}
+            </span>
+            <span className={styles['foreign-word-sub']}>{meaning.foreignMeaning}</span>
+            <span className={styles['foreign-word-sub']}>{meaning.relatedWords}</span>
+          </div>
+        </Fragment>
+      ))}
     </>
   );
 };

--- a/frontend/src/components/LearningCard/WordSection.tsx
+++ b/frontend/src/components/LearningCard/WordSection.tsx
@@ -1,4 +1,4 @@
-import { CardDetail } from '@/types/schemes';
+import { KoreanCardDetail } from '@/types/schemes';
 
 import styles from './WordSection.module.scss';
 
@@ -9,11 +9,11 @@ const levelStars = {
 };
 
 interface WordSectionProps {
-  card: CardDetail;
+  card: KoreanCardDetail;
 }
 
 const WordSection = ({ card }: WordSectionProps) => {
-  const levelLabel = levelStars[card.difficulty as keyof typeof levelStars] || '';
+  const levelLabel = levelStars[card.level as keyof typeof levelStars] || '';
 
   return (
     <>
@@ -23,16 +23,16 @@ const WordSection = ({ card }: WordSectionProps) => {
         <div className={styles['korean-info-container']}>
           <span className={styles['korean-level']}>{levelLabel}</span>
           <div className={styles['korean-info-sub-container']}>
-            <span className={styles['pronunciation']}>{`[${card.pronunciation}]`}</span>
-            <span className={styles['origin']}>{card.originalLanguage ?? ''}</span>
+            <span className={styles['pronunciation']}>{`[${card.meanings.pronunciation}]`}</span>
+            <span className={styles['origin']}>{card.meanings.originalLanguage ?? ''}</span>
           </div>
         </div>
       </div>
       <div className={styles['foreign-container']}>
         <span className={styles['foreign-word']}>
-          1. {card.partsOfSpeech} {card.foreignWord}
+          1. {card.meanings.partsOfSpeech} {card.meanings.foreignWord}
         </span>
-        <span className={styles['foreign-word-sub']}>{card.relatedWords}</span>
+        <span className={styles['foreign-word-sub']}>{card.meanings.relatedWords}</span>
       </div>
     </>
   );

--- a/frontend/src/components/ProgressBar/DeckProgressBar.tsx
+++ b/frontend/src/components/ProgressBar/DeckProgressBar.tsx
@@ -18,8 +18,7 @@ const DeckProgressBar = ({
   className,
   isExpanded
 }: DeckProgressBarProps) => {
-  const { maturityCounts, overdueCounts, cardCounts } = deck;
-  const learningCounts = cardCounts - maturityCounts - overdueCounts;
+  const { newCounts, learningCounts, maturityCounts, overdueCounts } = deck;
 
   useEffect(() => {
     console.log(deck);
@@ -45,8 +44,8 @@ const DeckProgressBar = ({
       color: LEARNING_PROGRESS_BAR_COLORS.learning
     },
     {
-      value: 0,
-      label: isExpanded ? 0 : '',
+      value: newCounts,
+      label: isExpanded ? newCounts : '',
       tooltip: 'New',
       color: LEARNING_PROGRESS_BAR_COLORS.new
     }

--- a/frontend/src/components/ProgressBar/LearningProgressBar.tsx
+++ b/frontend/src/components/ProgressBar/LearningProgressBar.tsx
@@ -6,31 +6,32 @@ import { UserCard } from '@/types/schemes';
 import { Progress } from '@/types/Progress';
 import { LEARNING_PROGRESS_BAR_COLORS } from '@/constants/colors';
 import { useEffect, useMemo } from 'react';
+import { State } from 'ts-fsrs';
 
 const LearningProgressBar = ({ userCards }: { userCards: UserCard[]; className: string }) => {
   const progress: Progress[] = useMemo(
     () => [
       {
-        value: userCards.filter((card) => card.fsrsParameters.state === 'Matured').length || 0,
-        label: userCards.filter((card) => card.fsrsParameters.state === 'Matured').length,
+        value: userCards.filter((card) => card.studyInfo.state === State.Review).length || 0,
+        label: userCards.filter((card) => card.studyInfo.state === State.Review).length,
         tooltip: 'Matured',
         color: LEARNING_PROGRESS_BAR_COLORS.matured
       },
       {
-        value: userCards.filter((card) => card.fsrsParameters.state === 'Learning').length || 0,
-        label: userCards.filter((card) => card.fsrsParameters.state === 'Learning').length,
+        value: userCards.filter((card) => card.studyInfo.state === State.Learning).length || 0,
+        label: userCards.filter((card) => card.studyInfo.state === State.Learning).length,
         tooltip: 'Learning',
         color: LEARNING_PROGRESS_BAR_COLORS.learning
       },
       {
-        value: userCards.filter((card) => card.fsrsParameters.state === 'Overdue').length || 0,
-        label: userCards.filter((card) => card.fsrsParameters.state === 'Overdue').length,
+        value: userCards.filter((card) => card.studyInfo.state === State.Review).length || 0,
+        label: userCards.filter((card) => card.studyInfo.state === State.Review).length,
         tooltip: 'Overdue',
         color: LEARNING_PROGRESS_BAR_COLORS.overdue
       },
       {
-        value: userCards.filter((card) => card.fsrsParameters.state === 'New').length || 0,
-        label: userCards.filter((card) => card.fsrsParameters.state === 'New').length,
+        value: userCards.filter((card) => card.studyInfo.state === State.New).length || 0,
+        label: userCards.filter((card) => card.studyInfo.state === State.New).length,
         tooltip: 'New',
         color: LEARNING_PROGRESS_BAR_COLORS.new
       }

--- a/frontend/src/components/WordList/WordList.module.scss
+++ b/frontend/src/components/WordList/WordList.module.scss
@@ -41,6 +41,11 @@
       @include bp.respond-to('extra-large') {
         @include tp.title-large;
       }
+
+      .homograph-number {
+        @include tp.body-medium;
+        color: var(--md-sys-color-on-surface-variant);
+      }
     }
 
     .right-container {

--- a/frontend/src/components/WordList/WordList.tsx
+++ b/frontend/src/components/WordList/WordList.tsx
@@ -11,7 +11,13 @@ import { DUMMY_KOR_CARD_DETAIL } from '@/utils/dummyData';
 import styles from './WordList.module.scss';
 import { WordListProps } from './types';
 
-const WordList = ({ KoreanWord, ForeignWord, isHideKorean, isHideForeign }: WordListProps) => {
+const WordList = ({
+  KoreanWord,
+  ForeignWord,
+  isHideKorean,
+  isHideForeign,
+  homographNumber
+}: WordListProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [contentHeight, setContentHeight] = useState(0);
   const [cardState, setCardState] = useState<LearningCardState>({
@@ -47,7 +53,10 @@ const WordList = ({ KoreanWord, ForeignWord, isHideKorean, isHideForeign }: Word
       {!isExpanded && (
         <OutlinedCard className={styles.card} onClick={handleClick}>
           <div className={styles.content}>
-            <h3 className={styles['korean-word']}>{isHideKorean ? '' : KoreanWord}</h3>
+            <h3 className={styles['korean-word']}>
+              {isHideKorean ? '' : KoreanWord}
+              <span className={styles['homograph-number']}>{homographNumber}</span>
+            </h3>
             <div className={styles['right-container']}>
               <div className={styles.line}></div>
               <h3 className={styles['foreign-word']}>{isHideForeign ? '' : ForeignWord}</h3>

--- a/frontend/src/components/WordList/WordList.tsx
+++ b/frontend/src/components/WordList/WordList.tsx
@@ -6,7 +6,7 @@ import { OutlinedCard } from '../Card/Card';
 import LearningCard, { LearningCardState } from '@/components/LearningCard/LearningCard';
 
 import { MenuItem } from '@/types/Menu';
-import { DUMMY_CARD } from '@/utils/dummyData';
+import { DUMMY_KOR_CARD_DETAIL } from '@/utils/dummyData';
 
 import styles from './WordList.module.scss';
 import { WordListProps } from './types';
@@ -57,7 +57,7 @@ const WordList = ({ KoreanWord, ForeignWord, isHideKorean, isHideForeign }: Word
       )}
       {isExpanded && (
         <LearningCard
-          card={DUMMY_CARD}
+          card={DUMMY_KOR_CARD_DETAIL}
           cardState={cardState}
           toggleConjugation={toggleConjugation}
           toggleExample={toggleExample}

--- a/frontend/src/components/WordList/WordListCompact.module.scss
+++ b/frontend/src/components/WordList/WordListCompact.module.scss
@@ -14,3 +14,8 @@
 .foreign-word {
   @include tp.body-large;
 }
+
+.homograph-number {
+  @include tp.body-small;
+  color: var(--md-sys-color-on-surface-variant);
+}

--- a/frontend/src/components/WordList/WordListCompact.tsx
+++ b/frontend/src/components/WordList/WordListCompact.tsx
@@ -5,7 +5,12 @@ import { WordListProps } from './types';
 import { OutlinedCard } from '../Card/Card';
 import styles from './WordListCompact.module.scss';
 
-const WordListCompact = ({ KoreanWord, ForeignWord, isExpanded }: WordListProps) => {
+const WordListCompact = ({
+  KoreanWord,
+  ForeignWord,
+  isExpanded,
+  homographNumber
+}: WordListProps) => {
   const [expanded, setExpanded] = useState(isExpanded || false);
 
   useEffect(() => {
@@ -22,7 +27,10 @@ const WordListCompact = ({ KoreanWord, ForeignWord, isExpanded }: WordListProps)
       style={{ height: expanded ? '104px' : '56px' }}
       onClick={handleClick}
     >
-      <div className={styles['korean-word']}>{KoreanWord}</div>
+      <div className={styles['korean-word']}>
+        {KoreanWord}
+        <span className={styles['homograph-number']}>{homographNumber}</span>
+      </div>
       {expanded && <div className={styles['foreign-word']}>{ForeignWord}</div>}
     </OutlinedCard>
   );

--- a/frontend/src/components/WordList/WordListCompact.tsx
+++ b/frontend/src/components/WordList/WordListCompact.tsx
@@ -5,7 +5,7 @@ import { WordListProps } from './types';
 import { OutlinedCard } from '../Card/Card';
 import styles from './WordListCompact.module.scss';
 
-const wordListCompact = ({ KoreanWord, ForeignWord, isExpanded }: WordListProps) => {
+const WordListCompact = ({ KoreanWord, ForeignWord, isExpanded }: WordListProps) => {
   const [expanded, setExpanded] = useState(isExpanded || false);
 
   useEffect(() => {
@@ -28,4 +28,4 @@ const wordListCompact = ({ KoreanWord, ForeignWord, isExpanded }: WordListProps)
   );
 };
 
-export default wordListCompact;
+export default WordListCompact;

--- a/frontend/src/components/WordList/types.ts
+++ b/frontend/src/components/WordList/types.ts
@@ -1,7 +1,8 @@
 export interface WordListProps {
-    KoreanWord: string;
-    ForeignWord: string;
-    isExpanded?: boolean;
-    isHideKorean?: boolean;
-    isHideForeign?: boolean;
+  KoreanWord: string;
+  ForeignWord: string;
+  isExpanded?: boolean;
+  isHideKorean?: boolean;
+  isHideForeign?: boolean;
+  homographNumber: number;
 }

--- a/frontend/src/components/common/WordListPage.tsx
+++ b/frontend/src/components/common/WordListPage.tsx
@@ -10,7 +10,7 @@ import { Icon, IconButton } from '@/components/material-components/IconButton/Ic
 import { Menu, MenuItem } from '@/components/material-components/Menu';
 import WordList from '@/components/WordList/WordList';
 import WordListCompact from '@/components/WordList/WordListCompact';
-import { KoreanCardDetail } from '@/types/schemes';
+import { KoreanCardWithForeignWords } from '@/types/schemes';
 import styles from './WordListPage.module.scss';
 import { getCategoryType } from '@/types/Category';
 import { camelCase } from 'lodash';
@@ -19,7 +19,7 @@ export default function WordListPage({
   wordList,
   category
 }: {
-  wordList: KoreanCardDetail[];
+  wordList: KoreanCardWithForeignWords[];
   category: string;
 }) {
   const t = useTranslations();
@@ -114,7 +114,8 @@ export default function WordListPage({
             <WordListComponent
               key={index}
               KoreanWord={word.koreanWord}
-              ForeignWord={word.meanings[0].foreignWord}
+              ForeignWord={word.foreignWords[0]}
+              homographNumber={+word.homographNumber + 1}
               isExpanded={!isLarge && isExpanded}
               isHideKorean={isLarge && isHideKorean}
               isHideForeign={isLarge && isHideForeign}

--- a/frontend/src/components/common/WordListPage.tsx
+++ b/frontend/src/components/common/WordListPage.tsx
@@ -10,17 +10,16 @@ import { Icon, IconButton } from '@/components/material-components/IconButton/Ic
 import { Menu, MenuItem } from '@/components/material-components/Menu';
 import WordList from '@/components/WordList/WordList';
 import WordListCompact from '@/components/WordList/WordListCompact';
-import { CardDetail } from '@/types/schemes';
+import { KoreanCardDetail } from '@/types/schemes';
 import styles from './WordListPage.module.scss';
 import { getCategoryType } from '@/types/Category';
 import { camelCase } from 'lodash';
-
 
 export default function WordListPage({
   wordList,
   category
 }: {
-  wordList: CardDetail[];
+  wordList: KoreanCardDetail[];
   category: string;
 }) {
   const t = useTranslations();

--- a/frontend/src/components/common/WordListPage.tsx
+++ b/frontend/src/components/common/WordListPage.tsx
@@ -114,10 +114,10 @@ export default function WordListPage({
             <WordListComponent
               key={index}
               KoreanWord={word.koreanWord}
-              ForeignWord={word.meanings.foreignWord}
-              isExpanded={!isLarge ? isExpanded : undefined}
-              isHideKorean={isLarge ? isHideKorean : undefined}
-              isHideForeign={isLarge ? isHideForeign : undefined}
+              ForeignWord={word.meanings[0].foreignWord}
+              isExpanded={!isLarge && isExpanded}
+              isHideKorean={isLarge && isHideKorean}
+              isHideForeign={isLarge && isHideForeign}
             />
           ))}
         </div>

--- a/frontend/src/components/common/WordListPage.tsx
+++ b/frontend/src/components/common/WordListPage.tsx
@@ -114,7 +114,7 @@ export default function WordListPage({
             <WordListComponent
               key={index}
               KoreanWord={word.koreanWord}
-              ForeignWord={word.foreignWord}
+              ForeignWord={word.meanings.foreignWord}
               isExpanded={!isLarge ? isExpanded : undefined}
               isHideKorean={isLarge ? isHideKorean : undefined}
               isHideForeign={isLarge ? isHideForeign : undefined}

--- a/frontend/src/hooks/useStudyQueue.ts
+++ b/frontend/src/hooks/useStudyQueue.ts
@@ -10,6 +10,9 @@ import { getUserCards } from '@/api/study';
 import { RootState } from '@/store';
 import { DUMMY_RATING_PREVIEW } from '@/utils/dummyData';
 import { State } from 'ts-fsrs';
+import { getCardDetail } from '@/api/cards';
+import { useLocale } from 'next-intl';
+import { Locale } from '@/types/Locale';
 
 export const useStudyQueue = (category: Category) => {
   const initialStudyQueue = useAppSelector((state) => state.studyQueue[category]);
@@ -22,7 +25,8 @@ export const useStudyQueue = (category: Category) => {
   const [currentCardDetail, setCurrentCardDetail] = useState<KoreanCardDetail | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
-  const repeat = (rating: Rating) => {
+  const locale = useLocale() as Locale;
+  const repeat = async (rating: Rating) => {
     if (studyQueue === null || currentCard === null) return;
     const newStudyQueue = [
       ...studyQueue.filter((card) => card.userCardId !== currentCard.userCardId),
@@ -35,9 +39,8 @@ export const useStudyQueue = (category: Category) => {
       }
     ];
     setStudyQueue(newStudyQueue);
-    setCurrentCard(
-      newStudyQueue.filter((card) => card.studyInfo.state !== State.Review)[0] ?? null
-    );
+    const nextCard = newStudyQueue.filter((card) => card.studyInfo.state !== State.Review)[0];
+    setCurrentCard(nextCard ?? null);
   };
 
   useEffect(() => {
@@ -68,7 +71,21 @@ export const useStudyQueue = (category: Category) => {
 
   useEffect(() => {
     console.log('currentCard:', currentCard);
-  }, [currentCard]);
+
+    const fetchCardDetail = async () => {
+      if (currentCard) {
+        const cardDetail = await getCardDetail(
+          currentCard.koreanCard.cardId,
+          locale,
+          accessToken ?? ''
+        );
+        console.log('cardDetail', cardDetail);
+        setCurrentCardDetail(cardDetail);
+      }
+    };
+
+    fetchCardDetail();
+  }, [currentCard, accessToken, locale]);
 
   return { currentCard, currentCardDetail, studyQueue, intervalPreview, repeat, error };
 };

--- a/frontend/src/hooks/useStudyQueue.ts
+++ b/frontend/src/hooks/useStudyQueue.ts
@@ -9,6 +9,7 @@ import { Category } from '@/types/Category';
 import { getUserCards } from '@/api/study';
 import { RootState } from '@/store';
 import { DUMMY_RATING_PREVIEW } from '@/utils/dummyData';
+import { State } from 'ts-fsrs';
 
 export const useStudyQueue = (category: Category) => {
   const initialStudyQueue = useAppSelector((state) => state.studyQueue[category]);
@@ -26,15 +27,15 @@ export const useStudyQueue = (category: Category) => {
       ...studyQueue.filter((card) => card.cardId !== currentCard.cardId),
       {
         ...currentCard,
-        fsrsParameters: {
-          ...currentCard.fsrsParameters,
-          state: rating === 'again' ? 'Learning' : 'Matured'
+        studyInfo: {
+          ...currentCard.studyInfo,
+          state: rating === 'again' ? State.Learning : State.Review
         }
       }
     ];
     setStudyQueue(newStudyQueue);
     setCurrentCard(
-      newStudyQueue.filter((card) => card.fsrsParameters.state !== 'Matured')[0] ?? null
+      newStudyQueue.filter((card) => card.studyInfo.state !== State.Review)[0] ?? null
     );
   };
 
@@ -46,7 +47,7 @@ export const useStudyQueue = (category: Category) => {
         if (response && 'content' in response) {
           setStudyQueue(response.content);
           setCurrentCard(
-            response.content.filter((card) => card.fsrsParameters.state !== 'Matured')[0] ?? null
+            response.content.filter((card) => card.studyInfo.state !== State.Review)[0] ?? null
           );
         }
       } catch (error) {

--- a/frontend/src/hooks/useStudyQueue.ts
+++ b/frontend/src/hooks/useStudyQueue.ts
@@ -2,7 +2,7 @@ import { useAppSelector } from '@/store/hooks';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { UserCard } from '@/types/schemes';
+import { KoreanCardDetail, UserCard } from '@/types/schemes';
 import { Rating } from '@/types/IntervalPreview';
 import { Category } from '@/types/Category';
 
@@ -19,6 +19,7 @@ export const useStudyQueue = (category: Category) => {
 
   const [studyQueue, setStudyQueue] = useState<UserCard[] | null>(initialStudyQueue || null);
   const [currentCard, setCurrentCard] = useState<UserCard | null>(null);
+  const [currentCardDetail, setCurrentCardDetail] = useState<KoreanCardDetail | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
   const repeat = (rating: Rating) => {
@@ -69,5 +70,5 @@ export const useStudyQueue = (category: Category) => {
     console.log('currentCard:', currentCard);
   }, [currentCard]);
 
-  return { currentCard, studyQueue, intervalPreview, repeat, error };
+  return { currentCard, currentCardDetail, studyQueue, intervalPreview, repeat, error };
 };

--- a/frontend/src/hooks/useStudyQueue.ts
+++ b/frontend/src/hooks/useStudyQueue.ts
@@ -6,7 +6,7 @@ import { KoreanCardDetail, UserCard } from '@/types/schemes';
 import { Rating } from '@/types/IntervalPreview';
 import { Category } from '@/types/Category';
 
-import { getUserCards } from '@/api/study';
+import { getLearningCards } from '@/api/study';
 import { RootState } from '@/store';
 import { DUMMY_RATING_PREVIEW } from '@/utils/dummyData';
 import { State } from 'ts-fsrs';
@@ -46,7 +46,7 @@ export const useStudyQueue = (category: Category) => {
   useEffect(() => {
     const fetchCards = async () => {
       try {
-        const response = await getUserCards('new', category, accessToken ?? '');
+        const response = await getLearningCards('new', category, accessToken ?? '');
         console.log('fetchCards', response);
         if (response && 'content' in response) {
           setStudyQueue(response.content);

--- a/frontend/src/hooks/useStudyQueue.ts
+++ b/frontend/src/hooks/useStudyQueue.ts
@@ -24,7 +24,7 @@ export const useStudyQueue = (category: Category) => {
   const repeat = (rating: Rating) => {
     if (studyQueue === null || currentCard === null) return;
     const newStudyQueue = [
-      ...studyQueue.filter((card) => card.cardId !== currentCard.cardId),
+      ...studyQueue.filter((card) => card.userCardId !== currentCard.userCardId),
       {
         ...currentCard,
         studyInfo: {

--- a/frontend/src/types/schemes.ts
+++ b/frontend/src/types/schemes.ts
@@ -20,14 +20,26 @@ export interface Card {
   foreignWord: string;
 }
 
-export interface CardDetail extends Card {
-  originalLanguage: string;
+export interface KoreanCard {
   homographNumber: number;
-  partsOfSpeech: string;
-  pronunciation: string;
-  relatedWords: string;
-  inflection: string;
-  exampleUsage: string;
+  level: Difficulty;
+  topics: string[];
+  cardId: number;
+  koreanWord: string;
+}
+
+export interface KoreanCardDetail extends KoreanCard {
+  meanings: {
+    foreignMeaning: string;
+    partsOfSpeech: string;
+    pronunciation: string;
+    languageCode: Locale;
+    originalLanguage: string;
+    foreignWord: string;
+    relatedWords: string;
+    inflection: string;
+    exampleUsage: string;
+  };
 }
 
 export type StudyInfo = {
@@ -42,12 +54,16 @@ export type StudyInfoDTO = Omit<
   state: 'New' | 'Learning' | 'Review' | 'Relearning';
 };
 
-export interface UserCard extends CardDetail {
+export interface UserCard {
+  koreanCard: KoreanCard;
   studyInfo: StudyInfo;
+  userCardId: number;
 }
 
-export interface UserCardDTO extends CardDetail {
+export interface UserCardDTO {
+  koreanCard: KoreanCard;
   studyInfo: StudyInfoDTO;
+  userCardId: number;
 }
 
 export interface Deck {

--- a/frontend/src/types/schemes.ts
+++ b/frontend/src/types/schemes.ts
@@ -88,3 +88,9 @@ export type UserOption = {
   utcOffset: number | null;
   languageCode: Locale;
 };
+
+export type TokenDTO = {
+  accessToken: string;
+  refreshToken: string;
+  isSetup: boolean;
+};

--- a/frontend/src/types/schemes.ts
+++ b/frontend/src/types/schemes.ts
@@ -1,5 +1,7 @@
 import { Difficulty, Category } from './Category';
 import { Locale } from './Locale';
+import { SnakeToCamelCase } from './typeTransform';
+import { Card as FSRSCard, State } from 'ts-fsrs';
 
 export type StudyType = 'review' | 'new';
 
@@ -18,33 +20,6 @@ export interface Card {
   foreignWord: string;
 }
 
-export interface FSRSParameters {
-  lapses: number;
-  reps: number;
-  due: Date;
-  difficulty: number;
-  scheduledDays: number;
-  lastReview: string;
-  state: string;
-  stability: number;
-}
-
-export interface CardStudyInfo extends FSRSParameters {
-  cardId: number;
-  nextStudyDate: string;
-}
-
-export interface StudyCardForm {
-  lapses: number;
-  reps: number;
-  due: Date;
-  scheduledDays: number;
-  lastReview: string;
-  state: string;
-  stability: number;
-  difficulty: number;
-}
-
 export interface CardDetail extends Card {
   originalLanguage: string;
   homographNumber: number;
@@ -55,14 +30,24 @@ export interface CardDetail extends Card {
   exampleUsage: string;
 }
 
+export type StudyInfo = {
+  [K in keyof FSRSCard as SnakeToCamelCase<K>]: FSRSCard[K];
+};
+
+export type StudyInfoDTO = Omit<
+  StudyInfo,
+  'lastReview' | 'state' | 'elapsedDays' | 'learningSteps'
+> & {
+  lastReview: string | null;
+  state: 'New' | 'Learning' | 'Review' | 'Relearning';
+};
+
 export interface UserCard extends CardDetail {
-  fsrsParameters: FSRSParameters;
+  studyInfo: StudyInfo;
 }
 
-export interface UserCardServerResponse extends Omit<CardDetail, 'difficulty'>, FSRSParameters {
-  // 서버에서는 difficulty가 아니라 level로 받아옴
-  level: Difficulty;
-  userCardId: number;
+export interface UserCardDTO extends CardDetail {
+  studyInfo: StudyInfoDTO;
 }
 
 export interface Deck {
@@ -88,28 +73,21 @@ export type UserOption = {
   languageCode: Locale;
 };
 
-export function convertUserCardServerResponseToUserCard(card: UserCardServerResponse): UserCard {
-  const {
+export function convertUserCardDTOToUserCard(card: UserCardDTO): UserCard {
+  const { studyInfo, ...rest } = card;
+  const { lapses, reps, due, scheduledDays, stability, difficulty, state } = studyInfo;
+  const newStudyInfo = {
     lapses,
     reps,
     due,
     scheduledDays,
-    lastReview,
+    lastReview: studyInfo.lastReview ? new Date(studyInfo.lastReview) : undefined,
     stability,
     difficulty,
-    state,
-    level,
-    ...rest
-  } = card;
-  const fsrsParameters = {
-    lapses,
-    reps,
-    due,
-    scheduledDays,
-    lastReview,
-    stability,
-    difficulty,
-    state
-  };
-  return { ...rest, difficulty: level, fsrsParameters };
+    state: state === 'New' ? State.New : state === 'Learning' ? State.Learning : State.Review,
+    elapsedDays: 0,
+    learningSteps: 0
+  } as StudyInfo;
+
+  return { ...rest, studyInfo: newStudyInfo };
 }

--- a/frontend/src/types/schemes.ts
+++ b/frontend/src/types/schemes.ts
@@ -1,7 +1,7 @@
 import { Difficulty, Category } from './Category';
 import { Locale } from './Locale';
 import { SnakeToCamelCase } from './typeTransform';
-import { Card as FSRSCard, State } from 'ts-fsrs';
+import { Card as FSRSCard } from 'ts-fsrs';
 
 export type StudyType = 'review' | 'new';
 
@@ -88,22 +88,3 @@ export type UserOption = {
   utcOffset: number | null;
   languageCode: Locale;
 };
-
-export function convertUserCardDTOToUserCard(card: UserCardDTO): UserCard {
-  const { studyInfo, ...rest } = card;
-  const { lapses, reps, due, scheduledDays, stability, difficulty, state } = studyInfo;
-  const newStudyInfo = {
-    lapses,
-    reps,
-    due,
-    scheduledDays,
-    lastReview: studyInfo.lastReview ? new Date(studyInfo.lastReview) : undefined,
-    stability,
-    difficulty,
-    state: state === 'New' ? State.New : state === 'Learning' ? State.Learning : State.Review,
-    elapsedDays: 0,
-    learningSteps: 0
-  } as StudyInfo;
-
-  return { ...rest, studyInfo: newStudyInfo };
-}

--- a/frontend/src/types/schemes.ts
+++ b/frontend/src/types/schemes.ts
@@ -67,12 +67,12 @@ export interface UserCardDTO {
 }
 
 export interface Deck {
-  overdueRate: number;
-  cardCounts: number;
-  overdueCounts: number;
-  maturityRate: number;
-  maturityCounts: number;
   category: Category;
+  cardCounts: number;
+  learningCounts: number;
+  newCounts: number;
+  overdueCounts: number;
+  maturityCounts: number;
 }
 
 export interface UserStudyHistory {

--- a/frontend/src/types/schemes.ts
+++ b/frontend/src/types/schemes.ts
@@ -42,6 +42,10 @@ export interface KoreanCardDetail extends KoreanCard {
   }>;
 }
 
+export interface KoreanCardWithForeignWords extends KoreanCard {
+  foreignWords: string[];
+}
+
 export type StudyInfo = {
   [K in keyof FSRSCard as SnakeToCamelCase<K>]: FSRSCard[K];
 };

--- a/frontend/src/types/schemes.ts
+++ b/frontend/src/types/schemes.ts
@@ -29,7 +29,7 @@ export interface KoreanCard {
 }
 
 export interface KoreanCardDetail extends KoreanCard {
-  meanings: {
+  meanings: Array<{
     foreignMeaning: string;
     partsOfSpeech: string;
     pronunciation: string;
@@ -39,7 +39,7 @@ export interface KoreanCardDetail extends KoreanCard {
     relatedWords: string;
     inflection: string;
     exampleUsage: string;
-  };
+  }>;
 }
 
 export type StudyInfo = {

--- a/frontend/src/types/typeTransform.ts
+++ b/frontend/src/types/typeTransform.ts
@@ -1,0 +1,3 @@
+export type SnakeToCamelCase<S extends string> = S extends `${infer T}_${infer U}`
+  ? `${T}${Capitalize<SnakeToCamelCase<U>>}`
+  : S;

--- a/frontend/src/utils/converter.ts
+++ b/frontend/src/utils/converter.ts
@@ -57,6 +57,6 @@ export function toStudyInfoDTO(studyInfo: StudyInfo): StudyInfoDTO {
 export function toKoreanCardDetail(card: UserCardDTO): KoreanCardDetail {
   return {
     ...DUMMY_KOR_CARD_DETAIL,
-    ...card.koreanCard
+    ...card
   };
 }

--- a/frontend/src/utils/converter.ts
+++ b/frontend/src/utils/converter.ts
@@ -2,6 +2,7 @@ import { dateDiffInDays, State } from 'ts-fsrs';
 
 import { KoreanCardDetail, StudyInfo, StudyInfoDTO, UserCard, UserCardDTO } from '@/types/schemes';
 import { DUMMY_KOR_CARD_DETAIL } from './dummyData';
+import { getCategoryType } from '@/types/Category';
 
 const STATE_MAP = {
   New: State.New,
@@ -59,4 +60,19 @@ export function toKoreanCardDetail(card: UserCardDTO): KoreanCardDetail {
     ...DUMMY_KOR_CARD_DETAIL,
     ...card
   };
+}
+
+// 서버에서 사용하는 명칭으로 변경
+export function normalizeQuery(query: string) {
+  switch (query) {
+    case 'difficulty':
+      return 'level';
+    case 'new':
+      return 'study';
+    default:
+      if (getCategoryType(query) === 'meaning') {
+        return query.toUpperCase();
+      }
+      return query;
+  }
 }

--- a/frontend/src/utils/converter.ts
+++ b/frontend/src/utils/converter.ts
@@ -1,0 +1,53 @@
+import { dateDiffInDays, State } from 'ts-fsrs';
+
+import { StudyInfo, StudyInfoDTO, UserCard, UserCardDTO } from '@/types/schemes';
+
+const STATE_MAP = {
+  New: State.New,
+  Learning: State.Learning,
+  Review: State.Review,
+  Relearning: State.Relearning
+} as const;
+
+// 서버에서 받은 데이터를 클라이언트에서 사용할 수 있는 형식으로 변환
+export function toUserCard(card: UserCardDTO): UserCard {
+  const { studyInfo, koreanCard, userCardId } = card;
+  const { due, stability, difficulty, scheduledDays, reps, lapses, state, lastReview } = studyInfo;
+
+  const newStudyInfo = {
+    due,
+    stability,
+    difficulty,
+    elapsedDays: lastReview ? dateDiffInDays(new Date(lastReview), new Date()) : 0,
+    scheduledDays,
+    reps,
+    lapses,
+    learningSteps: 0,
+    state: STATE_MAP[state],
+    lastReview: lastReview ? new Date(lastReview) : undefined
+  };
+
+  return { koreanCard, userCardId, studyInfo: newStudyInfo };
+}
+
+export function toStudyInfo(studyInfo: StudyInfoDTO): StudyInfo {
+  return {
+    ...studyInfo,
+    state: STATE_MAP[studyInfo.state],
+    learningSteps: 0,
+    elapsedDays: studyInfo.lastReview
+      ? dateDiffInDays(new Date(studyInfo.lastReview), new Date())
+      : 0,
+    lastReview: studyInfo.lastReview ? new Date(studyInfo.lastReview) : undefined
+  };
+}
+
+export function toStudyInfoDTO(studyInfo: StudyInfo): StudyInfoDTO {
+  return {
+    ...studyInfo,
+    state: Object.keys(STATE_MAP).find(
+      (key) => STATE_MAP[key as keyof typeof STATE_MAP] === studyInfo.state
+    ) as keyof typeof STATE_MAP,
+    lastReview: studyInfo.lastReview ? studyInfo.lastReview.toISOString() : null
+  };
+}

--- a/frontend/src/utils/converter.ts
+++ b/frontend/src/utils/converter.ts
@@ -1,6 +1,7 @@
 import { dateDiffInDays, State } from 'ts-fsrs';
 
-import { StudyInfo, StudyInfoDTO, UserCard, UserCardDTO } from '@/types/schemes';
+import { KoreanCardDetail, StudyInfo, StudyInfoDTO, UserCard, UserCardDTO } from '@/types/schemes';
+import { DUMMY_KOR_CARD_DETAIL } from './dummyData';
 
 const STATE_MAP = {
   New: State.New,
@@ -49,5 +50,13 @@ export function toStudyInfoDTO(studyInfo: StudyInfo): StudyInfoDTO {
       (key) => STATE_MAP[key as keyof typeof STATE_MAP] === studyInfo.state
     ) as keyof typeof STATE_MAP,
     lastReview: studyInfo.lastReview ? studyInfo.lastReview.toISOString() : null
+  };
+}
+
+// API 미구현으로 인해 타입만 맞춰서 반환
+export function toKoreanCardDetail(card: UserCardDTO): KoreanCardDetail {
+  return {
+    ...DUMMY_KOR_CARD_DETAIL,
+    ...card.koreanCard
   };
 }

--- a/frontend/src/utils/dummyData.ts
+++ b/frontend/src/utils/dummyData.ts
@@ -13,7 +13,8 @@ import {
   Deck,
   StudyInfoDTO,
   Paginated,
-  UserCard
+  UserCard,
+  KoreanCardWithForeignWords
 } from '@/types/schemes';
 import { State } from 'ts-fsrs';
 
@@ -86,20 +87,27 @@ export const DUMMY_KOR_CARD: KoreanCard = {
   topics: []
 };
 
+export const DUMMY_KOR_CARD_WITH_FOREIGN_WORDS: KoreanCardWithForeignWords = {
+  ...DUMMY_KOR_CARD,
+  foreignWords: ['near; close; adjacent']
+};
+
 export const DUMMY_KOR_CARD_DETAIL: KoreanCardDetail = {
   ...DUMMY_KOR_CARD,
-  meanings: {
-    foreignWord: 'near; close; adjacent',
-    foreignMeaning: 'near; close; adjacent',
-    languageCode: 'ko',
-    originalLanguage: '家具',
-    partsOfSpeech: '(adj.)',
-    pronunciation: '가깝따',
-    relatedWords: '반댓말 멀다2 반댓말 멀다2, 멀다2',
-    inflection: '가까운, 가꾸어(가꿔), 가까우니, 가깝습니다',
-    exampleUsage:
-      '<구> 안녕하세요\n<구> 안녕하세요\n<구> 안녕하세요\n<문> 안녕하세요\n<문> 안녕하세요\n<문> 안녕하세요\n<대화> 안녕하세요\n<대화> 안녕하세요\n<대화> 안녕하세요'
-  }
+  meanings: [
+    {
+      foreignWord: 'near; close; adjacent',
+      foreignMeaning: 'near; close; adjacent',
+      languageCode: 'ko',
+      originalLanguage: '家具',
+      partsOfSpeech: '(adj.)',
+      pronunciation: '가깝따',
+      relatedWords: '반댓말 멀다2 반댓말 멀다2, 멀다2',
+      inflection: '가까운, 가꾸어(가꿔), 가까우니, 가깝습니다',
+      exampleUsage:
+        '<구> 안녕하세요\n<구> 안녕하세요\n<구> 안녕하세요\n<문> 안녕하세요\n<문> 안녕하세요\n<문> 안녕하세요\n<대화> 안녕하세요\n<대화> 안녕하세요\n<대화> 안녕하세요'
+    }
+  ]
 };
 
 export const DUMMY_CARDS: Paginated<Card> = {

--- a/frontend/src/utils/dummyData.ts
+++ b/frontend/src/utils/dummyData.ts
@@ -5,7 +5,8 @@ import { Progress } from '@/types/Progress';
 
 import {
   Card,
-  CardDetail,
+  KoreanCard,
+  KoreanCardDetail,
   StudyInfo,
   UserOption,
   UserStudyHistory,
@@ -77,20 +78,28 @@ export const DUMMY_CARD: Card = {
   foreignWord: 'love'
 };
 
-export const DUMMY_CARD_DETAIL: CardDetail = {
+export const DUMMY_KOR_CARD: KoreanCard = {
   cardId: 1,
   koreanWord: '가깝다',
-  foreignWord: 'near; close; adjacent',
-  difficulty: 'easy',
-  languageCode: 'ko',
-  originalLanguage: '家具',
   homographNumber: 1,
-  partsOfSpeech: '(adj.)',
-  pronunciation: '가깝따',
-  relatedWords: '반댓말 멀다2 반댓말 멀다2, 멀다2',
-  inflection: '가까운, 가꾸어(가꿔), 가까우니, 가깝습니다',
-  exampleUsage:
-    '<구> 안녕하세요\n<구> 안녕하세요\n<구> 안녕하세요\n<문> 안녕하세요\n<문> 안녕하세요\n<문> 안녕하세요\n<대화> 안녕하세요\n<대화> 안녕하세요\n<대화> 안녕하세요'
+  level: 'easy',
+  topics: []
+};
+
+export const DUMMY_CARD_DETAIL: KoreanCardDetail = {
+  ...DUMMY_KOR_CARD,
+  meanings: {
+    foreignWord: 'near; close; adjacent',
+    foreignMeaning: 'near; close; adjacent',
+    languageCode: 'ko',
+    originalLanguage: '家具',
+    partsOfSpeech: '(adj.)',
+    pronunciation: '가깝따',
+    relatedWords: '반댓말 멀다2 반댓말 멀다2, 멀다2',
+    inflection: '가까운, 가꾸어(가꿔), 가까우니, 가깝습니다',
+    exampleUsage:
+      '<구> 안녕하세요\n<구> 안녕하세요\n<구> 안녕하세요\n<문> 안녕하세요\n<문> 안녕하세요\n<문> 안녕하세요\n<대화> 안녕하세요\n<대화> 안녕하세요\n<대화> 안녕하세요'
+  }
 };
 
 export const DUMMY_CARDS: Paginated<Card> = {
@@ -125,9 +134,9 @@ export const DUMMY_STUDY_INFO_DTO: StudyInfoDTO = {
 };
 
 export const DUMMY_USER_CARD: UserCard = {
-  ...DUMMY_CARD,
-  ...DUMMY_CARD_DETAIL,
-  studyInfo: DUMMY_STUDY_INFO
+  koreanCard: DUMMY_KOR_CARD,
+  studyInfo: DUMMY_STUDY_INFO,
+  userCardId: 1
 };
 
 export const DUMMY_USER_CARDS: Paginated<UserCard> = {
@@ -135,16 +144,16 @@ export const DUMMY_USER_CARDS: Paginated<UserCard> = {
   pageSize: 1,
   page: 1,
   content: [
-    { ...DUMMY_USER_CARD, koreanWord: '하나', foreignWord: 'one', cardId: 1 },
-    { ...DUMMY_USER_CARD, koreanWord: '둘', foreignWord: 'two', cardId: 2 },
-    { ...DUMMY_USER_CARD, koreanWord: '셋', foreignWord: 'three', cardId: 3 },
-    { ...DUMMY_USER_CARD, koreanWord: '넷', foreignWord: 'four', cardId: 4 },
-    { ...DUMMY_USER_CARD, koreanWord: '다섯', foreignWord: 'five', cardId: 5 },
-    { ...DUMMY_USER_CARD, koreanWord: '여섯', foreignWord: 'six', cardId: 6 },
-    { ...DUMMY_USER_CARD, koreanWord: '일곱', foreignWord: 'seven', cardId: 7 },
-    { ...DUMMY_USER_CARD, koreanWord: '여덟', foreignWord: 'eight', cardId: 8 },
-    { ...DUMMY_USER_CARD, koreanWord: '아홉', foreignWord: 'nine', cardId: 9 },
-    { ...DUMMY_USER_CARD, koreanWord: '열', foreignWord: 'ten', cardId: 10 }
+    { ...DUMMY_USER_CARD, koreanCard: { ...DUMMY_KOR_CARD, koreanWord: '하나', cardId: 1 } },
+    { ...DUMMY_USER_CARD, koreanCard: { ...DUMMY_KOR_CARD, koreanWord: '둘', cardId: 2 } },
+    { ...DUMMY_USER_CARD, koreanCard: { ...DUMMY_KOR_CARD, koreanWord: '셋', cardId: 3 } },
+    { ...DUMMY_USER_CARD, koreanCard: { ...DUMMY_KOR_CARD, koreanWord: '넷', cardId: 4 } },
+    { ...DUMMY_USER_CARD, koreanCard: { ...DUMMY_KOR_CARD, koreanWord: '다섯', cardId: 5 } },
+    { ...DUMMY_USER_CARD, koreanCard: { ...DUMMY_KOR_CARD, koreanWord: '여섯', cardId: 6 } },
+    { ...DUMMY_USER_CARD, koreanCard: { ...DUMMY_KOR_CARD, koreanWord: '일곱', cardId: 7 } },
+    { ...DUMMY_USER_CARD, koreanCard: { ...DUMMY_KOR_CARD, koreanWord: '여덟', cardId: 8 } },
+    { ...DUMMY_USER_CARD, koreanCard: { ...DUMMY_KOR_CARD, koreanWord: '아홉', cardId: 9 } },
+    { ...DUMMY_USER_CARD, koreanCard: { ...DUMMY_KOR_CARD, koreanWord: '열', cardId: 10 } }
   ]
 };
 

--- a/frontend/src/utils/dummyData.ts
+++ b/frontend/src/utils/dummyData.ts
@@ -165,10 +165,10 @@ export const DUMMY_USER_CARDS: Paginated<UserCard> = {
 };
 
 export const DUMMY_DECK: Deck = {
-  overdueRate: 0.1,
   cardCounts: 100,
+  learningCounts: 10,
+  newCounts: 10,
   overdueCounts: 10,
-  maturityRate: 0.1,
   maturityCounts: 10,
   category: 'easy'
 };

--- a/frontend/src/utils/dummyData.ts
+++ b/frontend/src/utils/dummyData.ts
@@ -6,14 +6,15 @@ import { Progress } from '@/types/Progress';
 import {
   Card,
   CardDetail,
-  CardStudyInfo,
+  StudyInfo,
   UserOption,
   UserStudyHistory,
   Deck,
-  StudyCardForm,
+  StudyInfoDTO,
   Paginated,
   UserCard
 } from '@/types/schemes';
+import { State } from 'ts-fsrs';
 
 export const DUMMY_PROGRESS: Progress[] = [
   { value: 10, label: '10', tooltip: 'Matured', color: LEARNING_PROGRESS_BAR_COLORS.matured },
@@ -99,26 +100,26 @@ export const DUMMY_CARDS: Paginated<Card> = {
   content: [DUMMY_CARD, DUMMY_CARD, DUMMY_CARD]
 };
 
-export const DUMMY_CARD_STUDY_INFO: CardStudyInfo = {
+export const DUMMY_STUDY_INFO: StudyInfo = {
+  due: new Date(),
   lapses: 0,
   reps: 0,
   scheduledDays: 0,
-  cardId: 1,
-  lastReview: '2025-01-01',
-  nextStudyDate: '2025-01-01',
-  state: 'new',
+  lastReview: new Date('2025-01-01'),
+  state: State.New,
   stability: 0,
-  due: new Date(),
-  difficulty: 0
+  difficulty: 0,
+  elapsedDays: 0,
+  learningSteps: 0
 };
 
-export const DUMMY_STUDY_CARD_FORM: StudyCardForm = {
+export const DUMMY_STUDY_INFO_DTO: StudyInfoDTO = {
   lapses: 0,
   reps: 0,
   due: new Date(),
   scheduledDays: 0,
   lastReview: '2025-01-01',
-  state: 'new',
+  state: 'New',
   stability: 0,
   difficulty: 0
 };
@@ -126,7 +127,7 @@ export const DUMMY_STUDY_CARD_FORM: StudyCardForm = {
 export const DUMMY_USER_CARD: UserCard = {
   ...DUMMY_CARD,
   ...DUMMY_CARD_DETAIL,
-  fsrsParameters: DUMMY_STUDY_CARD_FORM
+  studyInfo: DUMMY_STUDY_INFO
 };
 
 export const DUMMY_USER_CARDS: Paginated<UserCard> = {

--- a/frontend/src/utils/dummyData.ts
+++ b/frontend/src/utils/dummyData.ts
@@ -86,7 +86,7 @@ export const DUMMY_KOR_CARD: KoreanCard = {
   topics: []
 };
 
-export const DUMMY_CARD_DETAIL: KoreanCardDetail = {
+export const DUMMY_KOR_CARD_DETAIL: KoreanCardDetail = {
   ...DUMMY_KOR_CARD,
   meanings: {
     foreignWord: 'near; close; adjacent',
@@ -107,6 +107,13 @@ export const DUMMY_CARDS: Paginated<Card> = {
   pageSize: 1,
   page: 1,
   content: [DUMMY_CARD, DUMMY_CARD, DUMMY_CARD]
+};
+
+export const DUMMY_KOR_CARD_DETAILS: Paginated<KoreanCardDetail> = {
+  size: 1,
+  pageSize: 1,
+  page: 1,
+  content: [DUMMY_KOR_CARD_DETAIL, DUMMY_KOR_CARD_DETAIL, DUMMY_KOR_CARD_DETAIL]
 };
 
 export const DUMMY_STUDY_INFO: StudyInfo = {


### PR DESCRIPTION
# 단어 테이블 구조 변경에 의한 타입 업데이트

## 변경사항
1. 타입 시스템 개선
   - 서버-클라이언트 간 타입명 통일
     - 서버 타입에 `DTO` 접미사 추가 (예: `KoreanCardDTO`)
   - 서버-클라이언트 타입 간 변환 함수 구현
   - `ts-fsrs` 패키지의 학습 관련 타입 통합

2. 데이터 구조 변경 대응
   - `Deck` 타입에서 state-rate 프로퍼티 삭제, state-counts만 사용
   - `UserCard`에서 단어 상세정보 분리
     - 단어 상세정보는 `getKoreanCardDetail` API를 통해 별도 조회
   - `KoreanCardWithForeignWords` 타입 추가 및 관련 컴포넌트 업데이트

3. API 호출 로직 수정
   - 단어 상세정보 조회 로직 추가

## 주의사항
- 추가 기능은 별도 브랜치에서 구현 예정
- 현재 PR은 타입 시스템 및 데이터 구조 변경에 초점